### PR TITLE
Addressing lots of spec review feedback

### DIFF
--- a/make.js
+++ b/make.js
@@ -466,13 +466,13 @@ function populateDictionaryEntryTypes(api) {
 function addAuthHeader(apiCall, tabbing) {
     switch (apiCall.auth) {
         case "EntityToken": {
-            var output = ("if (m_tokens->EntityToken.empty())\n" + tabbing + "{\n" + tabbing + "    return E_PLAYFAB_NOENTITYTOKEN;\n" + tabbing + "}\n");
-            output += (tabbing + "headers.emplace(\"X-EntityToken\", m_tokens->EntityToken);");
+            var output = ("auto& entityToken{ m_tokens->EntityToken() };\n" + tabbing + "if (!entityToken.token)\n" + tabbing + "{\n" + tabbing + "    return E_PLAYFAB_NOENTITYTOKEN;\n" + tabbing + "}\n");
+            output += (tabbing + "headers.emplace(\"X-EntityToken\", entityToken.token);");
             return output;
         }
         case "SessionTicket": {
-            output = ("if (m_tokens->SessionTicket.empty())\n" + tabbing + "{\n" + tabbing + "    return E_PLAYFAB_NOSESSIONTICKET;\n" + tabbing + "}\n");
-            output += (tabbing + "headers.emplace(\"X-Authorization\", m_tokens->SessionTicket);");
+            output = ("auto sessionTicket{ m_tokens->SessionTicket() };\n" + tabbing + "if (sessionTicket.empty())\n" + tabbing + "{\n" + tabbing + "    return E_PLAYFAB_NOSESSIONTICKET;\n" + tabbing + "}\n");
+            output += (tabbing + "headers.emplace(\"X-Authorization\", std::move(sessionTicket));");
             return output;
         }
         case "SecretKey": {
@@ -481,7 +481,7 @@ function addAuthHeader(apiCall, tabbing) {
             return output;
         }
         case "None": {
-            return "//No auth header required for this API";
+            return "// No auth header required for this API";
         }
         default: {
             throw Error("getAuthParams: Unknown auth type: " + apiCall.auth + " for " + apiCall.name);

--- a/project_files.json
+++ b/project_files.json
@@ -21,6 +21,8 @@
     "source\\AsyncOp.h": "Source",
     "source\\AsyncProvider.cpp": "Source",
     "source\\AsyncProvider.h": "Source",
+    "source\\AuthTokens.cpp": "Source",
+    "source\\AuthTokens.h": "Source",
     "source\\BaseModel.cpp": "Source",
     "source\\BaseModel.h": "Source",
     "source\\Entity.cpp": "Source",

--- a/source/code/include/playfab/PlayFabEntity.h
+++ b/source/code/include/playfab/PlayFabEntity.h
@@ -21,6 +21,21 @@ extern "C"
 /// </summary>
 typedef struct PlayFabEntity* PlayFabEntityHandle;
 
+typedef struct PlayFabEntityToken
+{
+    /// <summary>
+    /// The token used to set X-EntityToken for all entity based API calls.
+    /// </summary>
+    const char* token;
+
+    /// <summary>
+    /// (Optional) The time the token will expire, if it is an expiring token, in UTC.
+    /// </summary>
+    time_t const* expiration;
+
+} PlayFabEntityToken;
+
+
 /// <summary>
 /// Get the result from a PlayFab authentication API. See PlayFab*AuthApi.h for the various authentication options.
 /// </summary>
@@ -65,7 +80,6 @@ void PlayFabEntityCloseHandle(
 /// will be updated with the returned EntityToken and it will be used in future PlayFab calls.
 /// </summary>
 /// <param name="entityHandle">Existing PlayFabEntityHandle returned from an auth call.</param>
-/// <param name="request">Populated request object.</param>
 /// <param name="async">XAsyncBlock for the async operation.</param>
 /// <returns>Result code for this API operation.</returns>
 /// <remarks>
@@ -73,7 +87,6 @@ void PlayFabEntityCloseHandle(
 /// </remarks>
 HRESULT PlayFabEntityGetEntityTokenAsync(
     _In_ PlayFabEntityHandle entityHandle,
-    _In_ const PlayFabAuthenticationGetEntityTokenRequest* request,
     _Inout_ XAsyncBlock* async
 ) noexcept;
 
@@ -111,6 +124,18 @@ HRESULT PlayFabEntityGetEntityType(
 ) noexcept;
 
 /// <summary>
+/// Get the Entity token.
+/// </summary>
+/// <param name="entityHandle">PlayFabEntityHandle returned from a auth call.</param>
+/// <param name="entityToken">Returned pointer to the entityToken. The pointer is valid until the Entity object is cleaned up, though
+/// the token may expire before then.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT PlayFabEntityGetCachedEntityToken(
+    _In_ PlayFabEntityHandle entityHandle,
+    _Outptr_ const PlayFabEntityToken** entityToken
+) noexcept;
+
+/// <summary>
 /// Get combined player info. Will be null if combined player info was not requested requested during login (see <see cref="PlayFabClientGetPlayerCombinedInfoRequestParams"/>).
 /// </summary>
 /// <param name="entityHandle">PlayFabEntityHandle returned from a auth call.</param>
@@ -122,18 +147,18 @@ HRESULT PlayFabEntityGetEntityType(
 /// </remarks>
 HRESULT PlayFabEntityGetPlayerCombinedInfo(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabGetPlayerCombinedInfoResultPayload** playerCombinedInfo
+    _Outptr_result_maybenull_ const PlayFabGetPlayerCombinedInfoResultPayload** playerCombinedInfo
 ) noexcept;
 
 /// <summary>
-/// Get last login time. lastLoginTime will be set to null if entity has no previous login.
+/// Get last login time (prior to the login that resulted in this entityHandle). lastLoginTime will be set to null if entity has no previous login.
 /// </summary>
 /// <param name="entityHandle">PlayFabEntityHandle returned from a auth call.</param>
 /// <param name="lastLoginTime">Returned pointer to the last login time. Valid until the Entity object is cleaned up.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT PlayFabEntityGetLastLoginTime(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const time_t** lastLoginTime
+    _Outptr_result_maybenull_ const time_t** lastLoginTime
 ) noexcept;
 
 /// <summary>
@@ -144,7 +169,7 @@ HRESULT PlayFabEntityGetLastLoginTime(
 /// <returns>Result code for this API operation.</returns>
 HRESULT PlayFabEntityGetUserSettings(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabUserSettings** userSettings
+    _Outptr_result_maybenull_ const PlayFabUserSettings** userSettings
 ) noexcept;
 
 /// <summary>
@@ -155,7 +180,7 @@ HRESULT PlayFabEntityGetUserSettings(
 /// <returns>Result code for this API operation.</returns>
 HRESULT PlayFabEntityGetTreatmentAssignment(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabTreatmentAssignment** treatmentAssignment
+    _Outptr_result_maybenull_ const PlayFabTreatmentAssignment** treatmentAssignment
 ) noexcept;
 
 }

--- a/source/code/include/playfab/PlayFabEntity.h
+++ b/source/code/include/playfab/PlayFabEntity.h
@@ -21,6 +21,9 @@ extern "C"
 /// </summary>
 typedef struct PlayFabEntity* PlayFabEntityHandle;
 
+/// <summary>
+/// PlayFab EntityToken and its expiration time. Used internally to authenticate PlayFab service calls.
+/// </summary>
 typedef struct PlayFabEntityToken
 {
     /// <summary>
@@ -34,7 +37,6 @@ typedef struct PlayFabEntityToken
     time_t const* expiration;
 
 } PlayFabEntityToken;
-
 
 /// <summary>
 /// Get the result from a PlayFab authentication API. See PlayFab*AuthApi.h for the various authentication options.

--- a/source/code/include/playfab/PlayFabGlobal.h
+++ b/source/code/include/playfab/PlayFabGlobal.h
@@ -101,13 +101,13 @@ HRESULT PlayFabInitialize(
 
 #if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
 /// <summary>
-/// Create PlayFab global state. Should be only used when implementing server code.
+/// Create PlayFab global state. Should be only used when implementing admin or server code.
 /// </summary>
 /// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
 /// <param name="secretKey">Key to be used for Authentication for some APIs.</param>
 /// <param name="stateHandle">Pointer to PlayFabStateHandle to write.</param>
 /// <returns>Result code for this API operation.</returns>
-HRESULT PlayFabServerInitialize(
+HRESULT PlayFabAdminInitialize(
     _In_z_ const char* titleId,
     _In_opt_z_ const char* secretKey,
     _Outptr_ PlayFabStateHandle* stateHandle

--- a/source/code/include/playfab/PlayFabGlobal.h
+++ b/source/code/include/playfab/PlayFabGlobal.h
@@ -54,19 +54,13 @@ typedef void STDAPIVCALLTYPE PlayFabMemFreeFunction(
 /// <summary>
 /// Optionally sets the memory hook functions to allow callers to control route memory 
 /// allocations to their own memory manager. This must be called before PlayFabInitialize() 
-/// and can not be called again until after calling PlayFabCleanupAsync()
+/// and can not be called again once memory hooks have been set.
 ///
 /// This method allows the application to install custom memory allocation routines in order 
 /// to service all requests for new memory buffers instead of using default allocation routines.
-///
-/// The <paramref name="memAllocFunc" /> and <paramref name="memFreeFunc" /> parameters can be null
-/// pointers to restore the default routines. Both callback pointers must be null or both must 
-/// be non-null. Mixing custom and default routines is not permitted.
 /// </summary>
-/// <param name="memAllocFunc">A pointer to the custom allocation callback to use, or a null 
-/// pointer to restore the default.</param>
-/// <param name="memFreeFunc">A pointer to the custom freeing callback to use, or a null 
-/// pointer to restore the default.</param>
+/// <param name="memAllocFunc">A pointer to the custom allocation callback to use.</param>
+/// <param name="memFreeFunc">A pointer to the custom freeing callback to use.</param>
 /// <returns>HRESULT return code for this API operation.</returns>
 STDAPI PlayFabMemSetFunctions(
     _In_opt_ PlayFabMemAllocFunction* memAllocFunc,
@@ -75,12 +69,12 @@ STDAPI PlayFabMemSetFunctions(
 
 /// <summary>
 /// Gets the memory hook functions to allow callers to control route memory allocations to their 
-/// own memory manager.  This method allows the application get the default memory allocation routines.
+/// own memory manager. This method allows the application get the default memory allocation routines.
 /// This can be used along with PlayFabMemSetFunctions() to monitor all memory allocations.
 /// </summary>
-/// <param name="memAllocFunc">Set to the current allocation callback.  Returns the default routine 
+/// <param name="memAllocFunc">Set to the current allocation callback. Returns the default routine 
 /// if not previously set</param>
-/// <param name="memFreeFunc">Set to the to the current memory free callback.  Returns the default 
+/// <param name="memFreeFunc">Set to the to the current memory free callback. Returns the default 
 /// routine if not previously set</param>
 /// <returns>HRESULT return code for this API operation.</returns>
 STDAPI PlayFabMemGetFunctions(
@@ -99,10 +93,10 @@ typedef struct PlayFabGlobalState* PlayFabStateHandle;
 /// </summary>
 /// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
 /// <param name="secretKey">Key to be used for Authentication for some APIs.</param>
-/// <param name="stateHandle">Returned pointer to PlayFabStateHandle.</param>
+/// <param name="stateHandle">Pointer to PlayFabStateHandle to write.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT PlayFabInitialize(
-    _In_z_ const char* titleId, // Could this be a uint64_t?
+    _In_z_ const char* titleId,
     _In_opt_z_ const char* secretKey,
     _Outptr_ PlayFabStateHandle* stateHandle
 ) noexcept;

--- a/source/code/include/playfab/PlayFabGlobal.h
+++ b/source/code/include/playfab/PlayFabGlobal.h
@@ -92,14 +92,28 @@ typedef struct PlayFabGlobalState* PlayFabStateHandle;
 /// Create PlayFab global state.
 /// </summary>
 /// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
-/// <param name="secretKey">Key to be used for Authentication for some APIs.</param>
 /// <param name="stateHandle">Pointer to PlayFabStateHandle to write.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT PlayFabInitialize(
     _In_z_ const char* titleId,
+    _Outptr_ PlayFabStateHandle* stateHandle
+) noexcept;
+
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+/// <summary>
+/// Create PlayFab global state. Should be only used when implementing server code.
+/// </summary>
+/// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
+/// <param name="secretKey">Key to be used for Authentication for some APIs.</param>
+/// <param name="stateHandle">Pointer to PlayFabStateHandle to write.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT PlayFabServerInitialize(
+    _In_z_ const char* titleId,
     _In_opt_z_ const char* secretKey,
     _Outptr_ PlayFabStateHandle* stateHandle
 ) noexcept;
+#endif
+
 
 /// <summary>
 /// Cleanup PlayFab global state.

--- a/source/code/source/Api/PlayFabEntity.cpp
+++ b/source/code/source/Api/PlayFabEntity.cpp
@@ -34,14 +34,12 @@ void PlayFabEntityCloseHandle(
 
 HRESULT PlayFabEntityGetEntityTokenAsync(
     _In_ PlayFabEntityHandle entityHandle,
-    _In_ const PlayFabAuthenticationGetEntityTokenRequest* request,
     _Inout_ XAsyncBlock* async
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(request);
 
-    auto provider = MakeProvider(async, __FUNCTION__, std::bind(&Entity::GetEntityToken, entityHandle->entity.get(), *request, std::placeholders::_1));
+    auto provider = MakeProvider(async, __FUNCTION__, std::bind(&Entity::GetEntityToken, entityHandle->entity.get(), std::placeholders::_1));
     return Provider::Run(UniquePtr<Provider>(provider.release()));
 }
 
@@ -82,9 +80,21 @@ HRESULT PlayFabEntityGetEntityType(
     return S_OK;
 }
 
+HRESULT PlayFabEntityGetCachedEntityToken(
+    _In_ PlayFabEntityHandle entityHandle,
+    _Outptr_ const PlayFabEntityToken** entityToken
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(entityToken);
+
+    *entityToken = &entityHandle->entity->EntityToken();
+    return S_OK;
+}
+
 HRESULT PlayFabEntityGetPlayerCombinedInfo(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabGetPlayerCombinedInfoResultPayload** playerCombinedInfo
+    _Outptr_result_maybenull_ const PlayFabGetPlayerCombinedInfoResultPayload** playerCombinedInfo
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
@@ -96,7 +106,7 @@ HRESULT PlayFabEntityGetPlayerCombinedInfo(
 
 HRESULT PlayFabEntityGetLastLoginTime(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const time_t** lastLoginTime
+    _Outptr_result_maybenull_ const time_t** lastLoginTime
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
@@ -108,7 +118,7 @@ HRESULT PlayFabEntityGetLastLoginTime(
 
 HRESULT PlayFabEntityGetUserSettings(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabUserSettings** userSettings
+    _Outptr_result_maybenull_ const PlayFabUserSettings** userSettings
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
@@ -120,7 +130,7 @@ HRESULT PlayFabEntityGetUserSettings(
 
 HRESULT PlayFabEntityGetTreatmentAssignment(
     _In_ PlayFabEntityHandle entityHandle,
-    _Outptr_ const PlayFabTreatmentAssignment** treatmentAssignment
+    _Outptr_result_maybenull_ const PlayFabTreatmentAssignment** treatmentAssignment
 ) noexcept 
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);

--- a/source/code/source/Api/PlayFabGlobal.cpp
+++ b/source/code/source/Api/PlayFabGlobal.cpp
@@ -39,6 +39,14 @@ STDAPI PlayFabMemGetFunctions(
 
 HRESULT PlayFabInitialize(
     _In_z_ const char* titleId,
+    _Outptr_ PlayFabStateHandle* stateHandle
+) noexcept
+{
+    return PlayFabGlobalState::Create(titleId, nullptr, stateHandle);
+}
+
+HRESULT PlayFabServerInitialize(
+    _In_z_ const char* titleId,
     _In_opt_z_ const char* secretKey,
     _Outptr_ PlayFabStateHandle* stateHandle
 ) noexcept

--- a/source/code/source/Api/PlayFabGlobal.cpp
+++ b/source/code/source/Api/PlayFabGlobal.cpp
@@ -45,7 +45,7 @@ HRESULT PlayFabInitialize(
     return PlayFabGlobalState::Create(titleId, nullptr, stateHandle);
 }
 
-HRESULT PlayFabServerInitialize(
+HRESULT PlayFabAdminInitialize(
     _In_z_ const char* titleId,
     _In_opt_z_ const char* secretKey,
     _Outptr_ PlayFabStateHandle* stateHandle

--- a/source/code/source/Api/PlayFabGlobal.cpp
+++ b/source/code/source/Api/PlayFabGlobal.cpp
@@ -10,13 +10,7 @@ STDAPI PlayFabMemSetFunctions(
     _In_opt_ PlayFabMemFreeFunction* memFreeFunc
 ) noexcept
 {
-    // Require that the hooks be set together
-    if ((!memAllocFunc && memFreeFunc) || (memAllocFunc && !memFreeFunc))
-    {
-        return E_INVALIDARG;
-    }
-
-    PlayFab::Detail::SetMemoryHooks(memAllocFunc, memFreeFunc);
+    RETURN_IF_FAILED(PlayFab::Detail::SetMemoryHooks(memAllocFunc, memFreeFunc));
 
     // Try to set the memory hooks for libHttpClient as well. If it has already be initialized, there is nothing we can do
     HRESULT hr = HCMemSetFunctions(memAllocFunc, memFreeFunc);

--- a/source/code/source/AuthTokens.cpp
+++ b/source/code/source/AuthTokens.cpp
@@ -1,0 +1,87 @@
+#include "stdafx.h"
+#include "AuthTokens.h"
+
+#define AS_STRING(charPtr) (charPtr ? String{ charPtr } : String{})
+
+namespace PlayFab
+{
+
+EntityToken::EntityToken(const EntityTokenResponse& tokenResponse) :
+    PlayFabEntityToken{},
+    m_token{ AS_STRING(tokenResponse.entityToken) },
+    m_expiration{ tokenResponse.tokenExpiration ? *tokenResponse.tokenExpiration : StdExtra::optional<time_t>{} }
+{
+    token = m_token.empty() ? nullptr : m_token.data();
+    expiration = m_expiration ? m_expiration.operator->() : nullptr;
+}
+
+EntityToken::EntityToken(const AuthenticationModels::GetEntityTokenResponse& tokenResponse) :
+    PlayFabEntityToken{},
+    m_token{ tokenResponse.entityToken },
+    m_expiration{ tokenResponse.tokenExpiration }
+{
+    token = m_token.empty() ? nullptr : m_token.data();
+    expiration = m_expiration ? m_expiration.operator->() : nullptr;
+}
+
+EntityToken::EntityToken(const EntityToken& src) :
+    m_token{ src.m_token },
+    m_expiration{ src.m_expiration }
+{
+    token = m_token.empty() ? nullptr : m_token.data();
+    expiration = m_expiration ? m_expiration.operator->() : nullptr;
+}
+
+EntityToken::EntityToken(EntityToken&& src) :
+    PlayFabEntityToken{ src },
+    m_token{ std::move(src.m_token) },
+    m_expiration{ src.m_expiration }
+{
+    expiration = m_expiration ? m_expiration.operator->() : nullptr;
+}
+
+AuthTokens::AuthTokens(const LoginResult& result) :
+    m_sessionTicket{ result.sessionTicket }
+{
+    // Can this ever be missing from a LoginResult?
+    assert(result.entityToken);
+    m_entityTokens.emplace_front(*result.entityToken);
+    m_entityToken = &m_entityTokens.front();
+}
+
+AuthTokens::AuthTokens(const ClientModels::RegisterPlayFabUserResult& result) : 
+    m_sessionTicket{ result.sessionTicket }
+{
+    // Can this ever be missing from a RegisterPlayFabUserResult?
+    assert(result.entityToken);
+    m_entityTokens.emplace_front(*result.entityToken);
+    m_entityToken = &m_entityTokens.front();
+}
+
+AuthTokens::AuthTokens(const AuthenticationModels::GetEntityTokenResponse& result)
+{
+    m_entityTokens.emplace_front(result);
+    m_entityToken = &m_entityTokens.front();
+}
+
+EntityToken const& AuthTokens::EntityToken() const
+{
+    assert(m_entityToken);
+    return *m_entityToken;
+}
+
+String const& AuthTokens::SessionTicket() const
+{
+    return m_sessionTicket;
+}
+
+void AuthTokens::UpdateEntityToken(const AuthenticationModels::GetEntityTokenResponse& getEntityTokenResponse)
+{
+    // Very unlikely that multiple threads will be updating token at once, but could theoretically happen
+    // if title calls GetEntityToken multiple times simultatneously
+    std::lock_guard<std::mutex> lock{ m_mutex };
+    m_entityTokens.emplace_front(getEntityTokenResponse);
+    m_entityToken = &m_entityTokens.front();
+}
+
+}

--- a/source/code/source/AuthTokens.cpp
+++ b/source/code/source/AuthTokens.cpp
@@ -43,7 +43,6 @@ EntityToken::EntityToken(EntityToken&& src) :
 AuthTokens::AuthTokens(const LoginResult& result) :
     m_sessionTicket{ result.sessionTicket }
 {
-    // Can this ever be missing from a LoginResult?
     assert(result.entityToken);
     m_entityTokens.emplace_front(*result.entityToken);
     m_entityToken = &m_entityTokens.front();
@@ -52,7 +51,6 @@ AuthTokens::AuthTokens(const LoginResult& result) :
 AuthTokens::AuthTokens(const ClientModels::RegisterPlayFabUserResult& result) : 
     m_sessionTicket{ result.sessionTicket }
 {
-    // Can this ever be missing from a RegisterPlayFabUserResult?
     assert(result.entityToken);
     m_entityTokens.emplace_front(*result.entityToken);
     m_entityToken = &m_entityTokens.front();

--- a/source/code/source/AuthTokens.h
+++ b/source/code/source/AuthTokens.h
@@ -35,7 +35,9 @@ public:
     void UpdateEntityToken(const AuthenticationModels::GetEntityTokenResponse& getEntityTokenResponse);
 
 private:
+    // Most recent entity token. Mutex not required to read.
     std::atomic<PlayFab::EntityToken const*> m_entityToken;
+    // All entity tokens. Storing old entity tokens as well so we don't invalidate pointers returned to titles.
     List<PlayFab::EntityToken> m_entityTokens;
     String m_sessionTicket;
     std::mutex m_mutex;

--- a/source/code/source/AuthTokens.h
+++ b/source/code/source/AuthTokens.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <playfab/PlayFabEntity.h>
+#include <Client/ClientDataModels.h>
+#include <Authentication/AuthenticationDataModels.h>
+
+namespace PlayFab
+{
+
+class EntityToken : public PlayFabEntityToken
+{
+public:
+    EntityToken(const EntityTokenResponse& tokenResponse);
+    EntityToken(const AuthenticationModels::GetEntityTokenResponse& tokenResponse);
+    EntityToken(const EntityToken& src);
+    EntityToken(EntityToken&& src);
+    ~EntityToken() = default;
+
+private:
+    String m_token;
+    StdExtra::optional<time_t> m_expiration;
+};
+
+// Auth tokens needed by to make PlayFab service calls
+class AuthTokens
+{
+public:
+    AuthTokens(const LoginResult& loginResult);
+    AuthTokens(const ClientModels::RegisterPlayFabUserResult& registerUserResult);
+    AuthTokens(const AuthenticationModels::GetEntityTokenResponse& getEntityTokenResponse);
+
+    PlayFab::EntityToken const& EntityToken() const;
+    String const& SessionTicket() const;
+
+    void UpdateEntityToken(const AuthenticationModels::GetEntityTokenResponse& getEntityTokenResponse);
+
+private:
+    std::atomic<PlayFab::EntityToken const*> m_entityToken;
+    List<PlayFab::EntityToken> m_entityTokens;
+    String m_sessionTicket;
+    std::mutex m_mutex;
+};
+
+}

--- a/source/code/source/Entity.cpp.ejs
+++ b/source/code/source/Entity.cpp.ejs
@@ -16,7 +16,7 @@ for(var apiName in categorizedApis) {
 
 Entity::Entity(SharedPtr<HttpClient const> httpClient, const LoginResult& result) :
     m_httpClient{ std::move(httpClient) },
-    m_authTokens{ new (Allocator<AuthTokens>{}.allocate(1)) AuthTokens{ result.sessionTicket, AS_STRING(result.entityToken->entityToken) } },
+    m_authTokens{ MakeShared<AuthTokens>(result) },
     eventManagerAPI{ m_httpClient, m_authTokens },
     QoSAPI{ m_httpClient, m_authTokens },<%- apiInitializationList %>
     m_playFabId{ result.playFabId },
@@ -31,7 +31,7 @@ Entity::Entity(SharedPtr<HttpClient const> httpClient, const LoginResult& result
 
 Entity::Entity(SharedPtr<HttpClient const> httpClient, const ClientModels::RegisterPlayFabUserResult& result) :
     m_httpClient{ std::move(httpClient) },
-    m_authTokens{ new (Allocator<AuthTokens>{}.allocate(1)) AuthTokens{ result.sessionTicket, AS_STRING(result.entityToken->entityToken) } },
+    m_authTokens{ MakeShared<AuthTokens>(result) },
     eventManagerAPI{ m_httpClient, m_authTokens },
     QoSAPI{ m_httpClient, m_authTokens },<%- apiInitializationList %>
     m_playFabId{ result.playFabId },
@@ -43,7 +43,7 @@ Entity::Entity(SharedPtr<HttpClient const> httpClient, const ClientModels::Regis
 
 Entity::Entity(SharedPtr<HttpClient const> httpClient, const AuthenticationModels::GetEntityTokenResponse& result) :
     m_httpClient{ std::move(httpClient) },
-    m_authTokens{ new (Allocator<AuthTokens>{}.allocate(1)) AuthTokens{ "", result.entityToken } },
+    m_authTokens{ MakeShared<AuthTokens>(result) },
     eventManagerAPI{ m_httpClient, m_authTokens },
     QoSAPI{ m_httpClient, m_authTokens },<%- apiInitializationList %>
     m_entityId{ AS_STRING(result.entity->id) },
@@ -52,18 +52,21 @@ Entity::Entity(SharedPtr<HttpClient const> httpClient, const AuthenticationModel
 }
 
 AsyncOp<void> Entity::GetEntityToken(
-    const PlayFabAuthenticationGetEntityTokenRequest& request,
     const TaskQueue& queue
 )
 {
     UnorderedMap<String, String> headers;
-    if (!m_authTokens->EntityToken.empty())
+
+    auto& entityToken{ m_authTokens->EntityToken() };
+    auto sessionTicket{ m_authTokens->SessionTicket() };
+
+    if (entityToken.token)
     {
-        headers.emplace("X-EntityToken", m_authTokens->EntityToken);
+        headers.emplace("X-EntityToken", entityToken.token);
     }
-    else if (!m_authTokens->SessionTicket.empty())
+    else if (!sessionTicket.empty())
     {
-        headers.emplace("X-Authorization", m_authTokens->SessionTicket);
+        headers.emplace("X-Authorization", std::move(sessionTicket));
     }
     else
     {
@@ -71,6 +74,8 @@ AsyncOp<void> Entity::GetEntityToken(
         assert(false);
         return E_UNEXPECTED;
     }
+
+    PlayFabAuthenticationGetEntityTokenRequest request{};
 
     return m_httpClient->MakePostRequest(
         "/Authentication/GetEntityToken",
@@ -86,7 +91,8 @@ AsyncOp<void> Entity::GetEntityToken(
         {
             AuthenticationModels::GetEntityTokenResponse resultModel;
             resultModel.FromJson(serviceResponse.Data);
-            sharedThis->m_authTokens->EntityToken = resultModel.entityToken;
+            sharedThis->m_authTokens->UpdateEntityToken(resultModel);
+            // TODO Should we update these Id and Type? I don't think they can change and it invalidates previously returned pointers
             sharedThis->m_entityId = resultModel.entity->id;
             sharedThis->m_entityType = resultModel.entity->type;
             return S_OK;
@@ -98,19 +104,24 @@ AsyncOp<void> Entity::GetEntityToken(
     });
 }
 
-const String& Entity::PlayFabId() const
+String const& Entity::PlayFabId() const
 {
     return m_playFabId;
 }
 
-const String& Entity::EntityId() const
+String const& Entity::EntityId() const
 {
     return m_entityId;
 }
 
-const String& Entity::EntityType() const
+String const& Entity::EntityType() const
 {
     return m_entityType;
+}
+
+PlayFab::EntityToken const& Entity::EntityToken() const
+{
+    return m_authTokens->EntityToken();
 }
 
 GetPlayerCombinedInfoResultPayload const* Entity::PlayerCombinedInfo() const

--- a/source/code/source/Entity.cpp.ejs
+++ b/source/code/source/Entity.cpp.ejs
@@ -91,10 +91,12 @@ AsyncOp<void> Entity::GetEntityToken(
         {
             AuthenticationModels::GetEntityTokenResponse resultModel;
             resultModel.FromJson(serviceResponse.Data);
+
+            // We requested an EntityToken for this entity, so these should never change
+            assert(sharedThis->m_entityId == AS_STRING(resultModel.entity->id));
+            assert(sharedThis->m_entityType == AS_STRING(resultModel.entity->type));
+
             sharedThis->m_authTokens->UpdateEntityToken(resultModel);
-            // TODO Should we update these Id and Type? I don't think they can change and it invalidates previously returned pointers
-            sharedThis->m_entityId = resultModel.entity->id;
-            sharedThis->m_entityType = resultModel.entity->type;
             return S_OK;
         }
         else

--- a/source/code/source/Entity.h.ejs
+++ b/source/code/source/Entity.h.ejs
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AuthTokens.h>
 #include <Client/ClientDataModels.h>
 #include <Authentication/AuthenticationDataModels.h>
 #include <Events/Manager/EventManagerApi.h>
@@ -13,13 +14,6 @@ for(var apiName in categorizedApis) {
 
 namespace PlayFab
 {
-
-// Auth tokens needed by to make PlayFab service calls
-struct AuthTokens
-{
-    String SessionTicket;
-    String EntityToken;
-};
 
 // An entity authenticated with PlayFab via one of the various login methods. For more detail on PlayFab entities see the service
 // documentation here: https://docs.microsoft.com/en-us/gaming/playfab/features/data/entities/quickstart.
@@ -43,13 +37,14 @@ public:
     // Non-generated implementation for /Authentication/GetEntityToken API call. When GetEntityToken is called by an existing Entity, the service
     // call will be authenticated with either the EntityToken or the ClientSessionTicket. The calling Entity's AuthTokens will be updated with the returned 
     // EntityToken if the call succeeds.
-    AsyncOp<void> GetEntityToken(const PlayFabAuthenticationGetEntityTokenRequest& request, const TaskQueue& queue);
+    AsyncOp<void> GetEntityToken(const TaskQueue& queue);
 
     // Getter methods to retreive Entity properties. All data only guaranteed to be accurate at the time of login. Lifetime of returned data is tied
     // to Entity object.
-    const String& PlayFabId() const;
-    const String& EntityId() const;
-    const String& EntityType() const;
+    String const& PlayFabId() const;
+    String const& EntityId() const;
+    String const& EntityType() const;
+    PlayFab::EntityToken const& EntityToken() const;
     GetPlayerCombinedInfoResultPayload const* PlayerCombinedInfo() const;
     time_t const* LastLoginTime() const;
     UserSettings const* UserSettings() const;

--- a/source/code/source/Events/Manager/EventManagerApi.h
+++ b/source/code/source/Events/Manager/EventManagerApi.h
@@ -7,7 +7,7 @@
 
 namespace PlayFab
 {
-struct AuthTokens;
+class AuthTokens;
 
 namespace EventManager
 {

--- a/source/code/source/InternalMemory.cpp
+++ b/source/code/source/InternalMemory.cpp
@@ -24,22 +24,27 @@ MemoryHooks& GetMemoryHooks()
     return s_hooks;
 }
 
-void SetMemoryHooks(PlayFabMemAllocFunction* memAllocFunc, PlayFabMemFreeFunction* memFreeFunc)
+HRESULT SetMemoryHooks(PlayFabMemAllocFunction* memAllocFunc, PlayFabMemFreeFunction* memFreeFunc)
 {
-    assert((memAllocFunc && memFreeFunc) || (!memAllocFunc && !memFreeFunc));
+    // Memhooks can't be null
+    RETURN_HR_INVALIDARG_IF_NULL(memAllocFunc);
+    RETURN_HR_INVALIDARG_IF_NULL(memFreeFunc);
 
     auto& hooks = GetMemoryHooks();
-    if (memAllocFunc)
+
+    // Only allow hooks to be set once
+    if (hooks.alloc != DefaultAlloc || hooks.free != DefaultFree)
+    {
+        TRACE_ERROR("Memory Hooks can only be set once!");
+        return E_FAIL;
+    }
+    else
     {
         hooks.alloc = memAllocFunc;
         hooks.free = memFreeFunc;
     }
-    else
-    {
-        // reset to defaults
-        hooks.alloc = DefaultAlloc;
-        hooks.free = DefaultFree;
-    }
+
+    return S_OK;
 }
 
 }

--- a/source/code/source/InternalMemory.h
+++ b/source/code/source/InternalMemory.h
@@ -15,7 +15,7 @@ struct MemoryHooks
 };
 
 MemoryHooks& GetMemoryHooks();
-void SetMemoryHooks(PlayFabMemAllocFunction* memAllocFunc, PlayFabMemFreeFunction* memFreeFunc);
+HRESULT SetMemoryHooks(PlayFabMemAllocFunction* memAllocFunc, PlayFabMemFreeFunction* memFreeFunc);
 
 }
 

--- a/source/code/source/stdafx.h
+++ b/source/code/source/stdafx.h
@@ -15,6 +15,9 @@
 #include <assert.h>
 #include <atomic>
 
+#define ENABLE_PLAYFABSERVER_API
+#define ENABLE_PLAYFABADMIN_API
+
 // libHttpClient headers
 #include <httpClient/pal.h>
 #include <httpClient/async.h>

--- a/source/test/TestApp/ApiTests.cpp
+++ b/source/test/TestApp/ApiTests.cpp
@@ -273,7 +273,7 @@ void ApiTests::AddTests()
 
 void ApiTests::ClassSetUp()
 {
-    HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    HRESULT hr = PlayFabAdminInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
     if (SUCCEEDED(hr))
     {
         PlayFabClientLoginWithCustomIDRequest request{};

--- a/source/test/TestApp/ApiTests.cpp
+++ b/source/test/TestApp/ApiTests.cpp
@@ -273,7 +273,7 @@ void ApiTests::AddTests()
 
 void ApiTests::ClassSetUp()
 {
-    HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
     if (SUCCEEDED(hr))
     {
         PlayFabClientLoginWithCustomIDRequest request{};

--- a/source/test/TestApp/ApiTests.cpp
+++ b/source/test/TestApp/ApiTests.cpp
@@ -196,8 +196,7 @@ void ApiTests::TestGetEntityTokenWithAuthContext(TestContext& testContext)
 {
     auto async = std::make_unique<XAsyncHelper<XAsyncResult>>(testContext);
 
-    PlayFabAuthenticationGetEntityTokenRequest request{};
-    HRESULT hr = PlayFabEntityGetEntityTokenAsync(entityHandle, &request, &async->asyncBlock);
+    HRESULT hr = PlayFabEntityGetEntityTokenAsync(entityHandle, &async->asyncBlock);
     if (FAILED(hr))
     {
         testContext.Fail("PlayFabEntityGetEntityTokenAsync", hr);

--- a/source/test/TestApp/EntityTests.cpp
+++ b/source/test/TestApp/EntityTests.cpp
@@ -137,7 +137,7 @@ void EntityTests::AddTests()
 
 void EntityTests::ClassSetUp()
 {
-    HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
     UNREFERENCED_PARAMETER(hr);
 }
 

--- a/source/test/TestApp/EntityTests.cpp
+++ b/source/test/TestApp/EntityTests.cpp
@@ -27,6 +27,9 @@ struct AuthResult : public XAsyncResult
         const char* entityType;
         RETURN_IF_FAILED(PlayFabEntityGetEntityType(entityHandle, &entityType));
 
+        const PlayFabEntityToken* entityToken;
+        RETURN_IF_FAILED(PlayFabEntityGetCachedEntityToken(entityHandle, &entityToken));
+
         PlayFabGetPlayerCombinedInfoResultPayload const* playerCombinedInfo;
         RETURN_IF_FAILED(PlayFabEntityGetPlayerCombinedInfo(entityHandle, &playerCombinedInfo));
 
@@ -69,9 +72,67 @@ void EntityTests::TestClientLogin(TestContext& testContext)
     async.release();
 }
 
+void EntityTests::TestTokenRefresh(TestContext& testContext)
+{
+    PlayFabEntityHandle entityHandle{ nullptr };
+
+    {
+        XAsyncBlock async{};
+
+        PlayFabClientLoginWithCustomIDRequest request{};
+        request.customId = "CustomId";
+        bool createAccount = true;
+        request.createAccount = &createAccount;
+        request.titleId = testTitleData.titleId.data();
+
+        HRESULT hr = PlayFabClientLoginWithCustomIDAsync(stateHandle, &request, &async);
+        if (FAILED(hr))
+        {
+            testContext.Fail("PlayFabClientLoginWithCustomIDAsync", hr);
+            return;
+        }
+
+        XAsyncGetStatus(&async, true);
+        hr = PlayFabGetAuthResult(&async, &entityHandle);
+
+        if (FAILED(hr) || !entityHandle)
+        {
+            testContext.Fail("PlayFabGetAuthResult", hr);
+            return;
+        }
+
+        const PlayFabEntityToken* entityToken;
+        PlayFabEntityGetCachedEntityToken(entityHandle, &entityToken);
+    }
+
+    {
+        XAsyncBlock async{};
+
+        HRESULT hr = PlayFabEntityGetEntityTokenAsync(entityHandle, &async);
+        if (FAILED(hr))
+        {
+            testContext.Fail("PlayFabEntityGetEntityTokenAsync", hr);
+            return;
+        }
+
+        hr = XAsyncGetStatus(&async, true);
+        if (FAILED(hr))
+        {
+            testContext.Fail("PlayFabEntityGetEntityTokenAsync", hr);
+            return;
+        }
+
+        const PlayFabEntityToken* entityToken;
+        PlayFabEntityGetCachedEntityToken(entityHandle, &entityToken);
+    }
+
+    testContext.Pass();
+}
+
 void EntityTests::AddTests()
 {
     AddTest("TestClientLogin", &EntityTests::TestClientLogin);
+    AddTest("TestTokenRefresh", &EntityTests::TestTokenRefresh);
 }
 
 void EntityTests::ClassSetUp()

--- a/source/test/TestApp/EntityTests.cpp
+++ b/source/test/TestApp/EntityTests.cpp
@@ -137,7 +137,7 @@ void EntityTests::AddTests()
 
 void EntityTests::ClassSetUp()
 {
-    HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), &stateHandle);
     UNREFERENCED_PARAMETER(hr);
 }
 

--- a/source/test/TestApp/EntityTests.h
+++ b/source/test/TestApp/EntityTests.h
@@ -11,6 +11,7 @@ class EntityTests : public PlayFabApiTestCase
 {
 private:
     void TestClientLogin(TestContext& testContext);
+    void TestTokenRefresh(TestContext& testContext);
 
 protected:
     void AddTests() override;

--- a/source/test/TestApp/EventManagerTests.cpp
+++ b/source/test/TestApp/EventManagerTests.cpp
@@ -168,7 +168,7 @@ void EventManagerTests::AddTests()
 
 void EventManagerTests::ClassSetUp()
 {
-    PlayFabInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
 }
 
 void EventManagerTests::ClassTearDown()

--- a/source/test/TestApp/EventManagerTests.cpp
+++ b/source/test/TestApp/EventManagerTests.cpp
@@ -168,7 +168,7 @@ void EventManagerTests::AddTests()
 
 void EventManagerTests::ClassSetUp()
 {
-    PlayFabServerInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    PlayFabInitialize(testTitleData.titleId.data(), &stateHandle);
 }
 
 void EventManagerTests::ClassTearDown()

--- a/source/test/TestApp/PlatformLoginTest_default.cpp
+++ b/source/test/TestApp/PlatformLoginTest_default.cpp
@@ -68,7 +68,7 @@ namespace PlayFabUnit
 
     void PlatformLoginTest::ClassSetUp()
     {
-        HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), nullptr, &stateHandle);
+        HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), nullptr, &stateHandle);
         assert(SUCCEEDED(hr));
         UNREFERENCED_PARAMETER(hr);
     }

--- a/source/test/TestApp/PlatformLoginTest_default.cpp
+++ b/source/test/TestApp/PlatformLoginTest_default.cpp
@@ -68,7 +68,7 @@ namespace PlayFabUnit
 
     void PlatformLoginTest::ClassSetUp()
     {
-        HRESULT hr = PlayFabServerInitialize(testTitleData.titleId.data(), nullptr, &stateHandle);
+        HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), &stateHandle);
         assert(SUCCEEDED(hr));
         UNREFERENCED_PARAMETER(hr);
     }

--- a/source/test/TestApp/TestAppPch.h
+++ b/source/test/TestApp/TestAppPch.h
@@ -22,7 +22,7 @@
 #include <array>
 #include <assert.h>
 
-#define ENABLE_PLAYFABSERVER_API
+#define ENABLE_PLAYFABADMIN_API
 #include <playfab/PlayFab.h>
 
 // Test App still relying on a lot of internal types/APIs, but this should eventually be changed

--- a/source/test/TestApp/TestAppPch.h
+++ b/source/test/TestApp/TestAppPch.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <assert.h>
 
+#define ENABLE_PLAYFABSERVER_API
 #include <playfab/PlayFab.h>
 
 // Test App still relying on a lot of internal types/APIs, but this should eventually be changed

--- a/templates/Test.cpp.ejs
+++ b/templates/Test.cpp.ejs
@@ -51,7 +51,7 @@ for (var i = 0; i < categorizedApi.otherCalls.length; i++)
 
 void AutoGen<%- api.name %>Tests::ClassSetUp()
 {
-    HRESULT hr = PlayFabInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
+    HRESULT hr = PlayFabAdminInitialize(testTitleData.titleId.data(), testTitleData.developerSecretKey.data(), &stateHandle);
     if (SUCCEEDED(hr))
     {
         PlayFabClientLoginWithCustomIDRequest request{};

--- a/templates/_Api.cpp.ejs
+++ b/templates/_Api.cpp.ejs
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "<%- api.name %>Api.h"
-#include "Entity.h"
 
 namespace PlayFab
 {

--- a/templates/_Api.h.ejs
+++ b/templates/_Api.h.ejs
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "<%- api.name %>DataModels.h"
+#include "AuthTokens.h"
 #include "HttpClient.h"
 #include "TaskQueue.h"
 
 namespace PlayFab
 {
-struct AuthTokens;
 
 class <%- api.name %>API
 {


### PR DESCRIPTION
* Expose EntityToken from PlayFabEntityHandle. 
* Remove request struct when refreshing EntityToken
* Don't allow mem hooks to be reset after setting once