### PR TITLE
Addressing GDK spec review feedback (Part 1)

### DIFF
--- a/XMLRefDocs.json
+++ b/XMLRefDocs.json
@@ -1,2 +1,5 @@
 {
+  "PFAuthenticationGetEntityTokenAsync": {
+    "summary": "Method to exchange a title SecretKey for an Entity Token."
+  }
 }

--- a/source/code/include/playfab/PFEntity.h.ejs
+++ b/source/code/include/playfab/PFEntity.h.ejs
@@ -38,22 +38,6 @@ typedef struct <%- prefix %>EntityToken
 
 } <%- prefix %>EntityToken;
 
-/// TODO move to PlayFabAuthentication.h maybe?
-/// <summary>
-/// Get the result from a PlayFab authentication API. See PlayFabAuthentication.h for the various authentication options.
-/// </summary>
-/// <param name="async">XAsyncBlock for the async operation.</param>
-/// <param name="entityHandle">Entity handle which can be used to call other PlayFab APIs.</param>
-/// <returns>Result code for this API operation.</returns>
-/// <remarks>
-/// If the auth call fails, entityHandle with be null. Otherwise, the handle must be closed with <%- prefix %>EntityCloseHandle
-/// when it is no longer needed.
-/// </remarks>
-HRESULT <%- prefix %>GetAuthResult(
-    _Inout_ XAsyncBlock* async,
-    _Out_ <%- prefix %>EntityHandle* entityHandle
-) noexcept;
-
 /// <summary>
 /// Duplicates a <%- prefix %>EntityHandle.
 /// </summary>
@@ -92,7 +76,7 @@ typedef void CALLBACK <%- prefix %>EntityTokenRefreshedCallback(
 /// </summary>
 /// <param name="entityHandle">Entity handle for the entity.</param>
 /// <param name="callback">The callback, <see cref="<%- prefix %>EntityTokenRefreshedCallback"/>.</param>
-/// <param name="context">Optional pointer to data used by the event handler.</param>
+/// <param name="context">Optional pointer to data used by the callback.</param>
 /// <param name="token">The token for unregistering the callback.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>EntityRegisterTokenRefreshedCallback(

--- a/source/code/include/playfab/PFGlobal.h.ejs
+++ b/source/code/include/playfab/PFGlobal.h.ejs
@@ -27,11 +27,8 @@ extern "C"
 /// <returns>A pointer to an allocated block of memory of the specified size, or a null 
 /// pointer if allocation failed.</returns>
 /// <param name="size">The size of the allocation to be made. This value will never be zero.</param>
-/// <param name="memoryType">An opaque identifier representing the internal category of 
-/// memory being allocated.</param>
 typedef _Ret_maybenull_ _Post_writable_byte_size_(size) void* STDAPIVCALLTYPE <%- prefix %>MemAllocFunction(
-    _In_ size_t size,
-    _In_ uint32_t memoryType
+    _In_ size_t size
 );
 
 /// <summary>
@@ -44,11 +41,8 @@ typedef _Ret_maybenull_ _Post_writable_byte_size_(size) void* STDAPIVCALLTYPE <%
 /// </summary>
 /// <param name="pointer">The pointer to the memory buffer previously allocated. This value will
 /// never be a null pointer.</param>
-/// <param name="memoryType">An opaque identifier representing the internal category of 
-/// memory being allocated.</param>
 typedef void STDAPIVCALLTYPE <%- prefix %>MemFreeFunction(
-    _In_ _Post_invalid_ void* pointer,
-    _In_ uint32_t memoryType
+    _In_ _Post_invalid_ void* pointer
 );
 
 /// <summary>

--- a/source/code/source/Api/PFEntity.cpp.ejs
+++ b/source/code/source/Api/PFEntity.cpp.ejs
@@ -5,14 +5,6 @@
 
 using namespace PlayFab;
 
-HRESULT <%- prefix %>GetAuthResult(
-    _In_ XAsyncBlock* async,
-    _Out_ <%- prefix %>EntityHandle* entityHandle
-) noexcept
-{
-    return XAsyncGetResult(async, nullptr, sizeof(<%- prefix %>EntityHandle), entityHandle, nullptr);
-}
-
 HRESULT <%- prefix %>EntityDuplicateHandle(
     _In_ <%- prefix %>EntityHandle entityHandle,
     _Out_ <%- prefix %>EntityHandle* duplicatedEntityHandle

--- a/source/code/source/Api/PFGlobal.cpp.ejs
+++ b/source/code/source/Api/PFGlobal.cpp.ejs
@@ -13,7 +13,15 @@ STDAPI <%- prefix %>MemSetFunctions(
     RETURN_IF_FAILED(PlayFab::Detail::SetMemoryHooks(memAllocFunc, memFreeFunc));
 
     // Try to set the memory hooks for libHttpClient as well. If it has already be initialized, there is nothing we can do
-    HRESULT hr = HCMemSetFunctions(memAllocFunc, memFreeFunc);
+    HRESULT hr = HCMemSetFunctions([](size_t size, HCMemoryType)
+        {
+            return PlayFab::Alloc(size);
+        },
+        [](void* pointer, HCMemoryType)
+        {
+            return PlayFab::Free(pointer);
+        });
+
     if (FAILED(hr) && hr != E_HC_ALREADY_INITIALISED)
     {
         return hr;

--- a/source/code/source/InternalMemory.cpp.ejs
+++ b/source/code/source/InternalMemory.cpp.ejs
@@ -6,12 +6,12 @@ namespace Detail
 {
 
 // Default memory functions
-_Ret_maybenull_ _Post_writable_byte_size_(size) void* DefaultAlloc(size_t size, uint32_t /* tag */) noexcept
+_Ret_maybenull_ _Post_writable_byte_size_(size) void* DefaultAlloc(size_t size) noexcept
 {
     return operator new(size);
 }
 
-void DefaultFree(_In_ _Post_invalid_ void* pointer, uint32_t /* tag */) noexcept
+void DefaultFree(_In_ _Post_invalid_ void* pointer) noexcept
 {
     operator delete(pointer);
 }
@@ -49,11 +49,9 @@ HRESULT SetMemoryHooks(<%- prefix %>MemAllocFunction* memAllocFunc, <%- prefix %
 
 }
 
-constexpr uint32_t playFabMemoryTag = 3302021;
-
 void* Alloc(size_t size)
 {
-    void* pointer = Detail::GetMemoryHooks().alloc(size, playFabMemoryTag);
+    void* pointer = Detail::GetMemoryHooks().alloc(size);
 
     assert(pointer);
     return pointer;
@@ -63,7 +61,7 @@ void Free(void* pointer) noexcept
 {
     if (pointer)
     {
-        Detail::GetMemoryHooks().free(pointer, playFabMemoryTag);
+        Detail::GetMemoryHooks().free(pointer);
     }
 }
 

--- a/source/test/TestApp/Tests/ApiTests.cpp
+++ b/source/test/TestApp/Tests/ApiTests.cpp
@@ -210,7 +210,7 @@ void ApiTests::TestGetEntityTokenWithSecretKey(TestContext& testContext)
 
         HRESULT Get(XAsyncBlock* async) override
         {
-            return PFGetAuthResult(async, &newEntityHandle);
+            return PFAuthenticationGetEntityTokenGetResult(async, &newEntityHandle);
         }
 
         ~GetEntityTokenResult()
@@ -287,7 +287,7 @@ void ApiTests::ClassSetUp()
             hr = XAsyncGetStatus(&async, true);
             if (SUCCEEDED(hr))
             {
-                PFGetAuthResult(&async, &entityHandle);
+                PFAuthenticationClientLoginGetResult(&async, &entityHandle);
             }
         }
     }

--- a/source/test/TestApp/Tests/EntityTests.cpp
+++ b/source/test/TestApp/Tests/EntityTests.cpp
@@ -16,7 +16,7 @@ struct AuthResult : public XAsyncResult
 
     HRESULT Get(XAsyncBlock* async) override
     {
-        RETURN_IF_FAILED(PFGetAuthResult(async, &entityHandle));
+        RETURN_IF_FAILED(PFAuthenticationClientLoginGetResult(async, &entityHandle));
 
         const char* playFabId;
         RETURN_IF_FAILED(PFEntityGetPlayFabId(entityHandle, &playFabId));
@@ -93,7 +93,7 @@ void EntityTests::TestManualTokenRefresh(TestContext& testContext)
         }
 
         XAsyncGetStatus(&async, true);
-        hr = PFGetAuthResult(&async, &authResult.entityHandle);
+        hr = PFAuthenticationClientLoginGetResult(&async, &authResult.entityHandle);
 
         if (FAILED(hr) || !&authResult.entityHandle)
         {

--- a/templates/PFCalls.cpp.ejs
+++ b/templates/PFCalls.cpp.ejs
@@ -8,6 +8,11 @@
 using namespace PlayFab;
 using namespace PlayFab::<%- featureGroup.name %>Models;
 <% var apiMemberName = featureGroup.name.charAt(0).toLowerCase() + featureGroup.name.slice(1) + "API";
+
+// There are many Login methods for both Client and Server, but we only want to define a single GetLoginResult method for each
+var getClientLoginResultDefined = false;
+var getServerLoginResultDefined = false;
+
 for (var i = 0; i < featureGroup.calls.length; i++) {
     var call = featureGroup.calls[i]; 
     var contextHandleParam = call.entityRequired ? globalPrefix + "EntityHandle contextHandle" : globalPrefix + "StateHandle contextHandle";
@@ -55,9 +60,42 @@ HRESULT <%- globalPrefix %>AuthenticationLoginWithXUserAsync(
 #endif
 <%  } // end if
 
-    if ((!call.resultDatatype) || call.entityReturned) { 
+    if (!call.resultDatatype) { 
         // No Get Result method needed
-    } else if (isFixedSize(call.resultDatatype)) { %>
+    } else if (call.resultDatatype.name === "LoginResult") {
+        // Custom logic for Client Login Result
+        if (!getClientLoginResultDefined) { 
+            getClientLoginResultDefined = true; %>
+HRESULT <%- prefix %>ClientLoginGetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept
+{
+    return XAsyncGetResult(async, nullptr, sizeof(<%- globalPrefix %>EntityHandle), entityHandle, nullptr);
+}
+<%      } // end if
+    } else if (call.resultDatatype.name === "ServerLoginResult") {
+        // Custom logic for Server Login result
+        if (!getServerLoginResultDefined) {
+            getServerLoginResultDefined = true; %>
+HRESULT <%- prefix %>ServerLoginGetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept
+{
+    return XAsyncGetResult(async, nullptr, sizeof(<%- globalPrefix %>EntityHandle), entityHandle, nullptr);
+}            
+<%      } // end if
+    } else if (call.entityReturned) {
+        /* Custom logic for all other calls that result in an Entity object*/ %>
+HRESULT <%- prefix %><%- call.name %>GetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept
+{
+    return XAsyncGetResult(async, nullptr, sizeof(<%- globalPrefix %>EntityHandle), entityHandle, nullptr);
+}
+<%  } else if (isFixedSize(call.resultDatatype)) { %>
 HRESULT <%- prefix %><%- call.name %>GetResult(
     _In_ XAsyncBlock* async,
     _Out_ <%- call.resultDatatype.prefix %><%- call.resultDatatype.name %>* result

--- a/templates/PFCalls.h.ejs
+++ b/templates/PFCalls.h.ejs
@@ -53,6 +53,10 @@ function callExclusionMacroEnd(call){
     return "";
 }
 
+// There are many Login methods for both Client and Server, but we only want to define a single GetLoginResult method for each
+var getClientLoginResultDeclared = false;
+var getServerLoginResultDeclared = false;
+
 for (var callIndex = 0; callIndex < featureGroup.calls.length; callIndex++) {
     var call = featureGroup.calls[callIndex]; 
     var contextHandleParam =  call.entityRequired ? globalPrefix + "EntityHandle entityHandle" : globalPrefix + "StateHandle stateHandle";
@@ -102,9 +106,63 @@ HRESULT <%- globalPrefix %>AuthenticationLoginWithXUserAsync(
 #endif
 <%  } // end if
 
-    if ((!call.resultDatatype) || call.entityReturned) { 
+    if (!call.resultDatatype) {
         // No Get Result method needed
-    } else if (isFixedSize(call.resultDatatype)) { %>
+    } else if (call.resultDatatype.name === "LoginResult") {
+        // Custom logic for Client Login Result
+        if (!getClientLoginResultDeclared) { 
+            getClientLoginResultDeclared = true; %>
+/// <symmary>
+/// Get the result from a <%- prefix %>ClientLogin* call.
+/// </symmary>
+/// <param name="async">XAsyncBlock for the async operation.</param>
+/// <param name="entityHandle">Entity handle which can be used to call other PlayFab APIs.</param>
+/// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// If the login attempt fails, entityHandle with be null. Otherwise, the handle must be closed with <%- globalPrefix %>EntityCloseHandle
+/// when it is no longer needed.
+/// </remarks>
+HRESULT <%- prefix %>ClientLoginGetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept;
+<%      } // end if
+    } else if (call.resultDatatype.name === "ServerLoginResult") {
+        // Custom logic for Server Login result
+        if (!getServerLoginResultDeclared) {
+            getServerLoginResultDeclared = true; %>
+/// <symmary>
+/// Get the result from a <%- prefix %>ServerLogin* call.
+/// </symmary>
+/// <param name="async">XAsyncBlock for the async operation.</param>
+/// <param name="entityHandle">Entity handle which can be used to call other PlayFab APIs.</param>
+/// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// If the login attempt fails, entityHandle with be null. Otherwise, the handle must be closed with <%- globalPrefix %>EntityCloseHandle
+/// when it is no longer needed.
+/// </remarks>
+HRESULT <%- prefix %>ServerLoginGetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept;
+<%      } // end if
+    } else if (call.entityReturned) {
+        /* Custom logic for all other calls that result in an Entity object*/ %>
+/// <symmary>
+/// Get the result from a <%- prefix %><%- call.name %>Async call.
+/// </symmary>
+/// <param name="async">XAsyncBlock for the async operation.</param>
+/// <param name="entityHandle">Entity handle which can be used to call other PlayFab APIs.</param>
+/// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// If the <%- prefix %><%- call.name %>Async call fails, entityHandle with be null. Otherwise, the handle must be closed with <%- globalPrefix %>EntityCloseHandle
+/// when it is no longer needed.
+/// </remarks>
+HRESULT <%- prefix %><%- call.name %>GetResult(
+    _In_ XAsyncBlock* async,
+    _Out_ <%- globalPrefix %>EntityHandle* entityHandle
+) noexcept;   
+<%  } else if (isFixedSize(call.resultDatatype)) { %>
 /// <summary>
 /// Gets the result of a successful <%- prefix %><%- call.name %>Async call.
 /// </summary>

--- a/templates/Test.cpp.ejs
+++ b/templates/Test.cpp.ejs
@@ -93,7 +93,7 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
             assert(SUCCEEDED(hr));
             if (SUCCEEDED(hr))
             {
-                hr = PFGetAuthResult(&async, &entityHandle);
+                hr = PFAuthenticationClientLoginGetResult(&async, &entityHandle);
                 assert(SUCCEEDED(hr) && entityHandle != nullptr);
 
                 hr = PFEntityGetPlayerCombinedInfo(entityHandle, &playerCombinedInfo);


### PR DESCRIPTION
* Remove memoryType parameter from mem hook functions
* Align naming of Login & LoginResult methods: PFGetAuthResult -> PFAuthenticationClientLoginGetResult + PFAuthenticationServerLoginGetResult + PFAuthenticationGetEntityTokenGetResult
* Fix GetEntityToken XML ref docs 