### PR TITLE
Addressing more Spec Review feedback

### DIFF
--- a/source/code/include/playfab/PFEntity.h.ejs
+++ b/source/code/include/playfab/PFEntity.h.ejs
@@ -9,8 +9,8 @@
 
 #include <httpClient/pal.h>
 #include <httpClient/async.h>
-#include <playfab/PFSharedDataModels.h>
-#include <playfab/PFAuthenticationDataModels.h>
+#include <playfab/<%- prefix %>SharedDataModels.h>
+#include <playfab/<%- prefix %>AuthenticationDataModels.h>
 
 extern "C"
 {
@@ -135,37 +135,65 @@ HRESULT <%- prefix %>EntityGetEntityTokenGetResult(
 ) noexcept;
 
 /// <summary>
-/// Get the Entity Id for an Entity.
+/// Get the size in bytes needed to store the <%- prefix %>EntityKey for an Entity.
 /// </summary>
 /// <param name="entityHandle"><%- prefix %>EntityHandle returned from a auth call.</param>
-/// <param name="entityId">Returned pointer to the entityId. Valid until the Entity object is cleaned up.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the EntityKey.</param>
 /// <returns>Result code for this API operation.</returns>
-HRESULT <%- prefix %>EntityGetEntityId(
+HRESULT <%- prefix %>EntityGetEntityKeySize(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const char** entityId
+    _Out_ size_t* bufferSize
 ) noexcept;
 
 /// <summary>
-/// Get the Entity type for an entity.
+/// Get the <%- prefix %>EntityKey for an entity.
 /// </summary>
 /// <param name="entityHandle"><%- prefix %>EntityHandle returned from a auth call.</param>
-/// <param name="entityId">Returned pointer to the entityType. Valid until the Entity object is cleaned up.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>EntityKey. The required size can be obtained from <%- prefix %>EntityGetEntityKeySize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityKey and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>EntityKey object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
 /// <returns>Result code for this API operation.</returns>
-HRESULT <%- prefix %>EntityGetEntityType(
+/// <remarks>
+/// entityKey is a pointer within buffer and does not need to be freed separately.
+/// </remarks>
+HRESULT <%- prefix %>EntityGetEntityKey(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const char** entityType
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityKey** entityKey,
+    _Out_opt_ size_t* bufferUsed
+) noexcept;
+
+/// <summary>
+/// Get the size in bytes needed to store the cached <%- prefix %>EntityToken for an Entity.
+/// </summary>
+/// <param name="entityHandle"><%- prefix %>EntityHandle returned from a auth call.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the cached <%- prefix %>EntityToken.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT <%- prefix %>EntityGetCachedEntityTokenSize(
+    _In_ <%- prefix %>EntityHandle entityHandle,
+    _Out_ size_t* bufferSize
 ) noexcept;
 
 /// <summary>
 /// Get the cached Entity token.
 /// </summary>
 /// <param name="entityHandle"><%- prefix %>EntityHandle returned from a auth call.</param>
-/// <param name="entityToken">Returned pointer to the entityToken. The pointer is valid until the Entity object is cleaned up, though
-/// the token may expire before then.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>EntityToken.  The required size can be obtained from <%- prefix %>EntityGetCachedEntityTokenSize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityToken and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>EntityToken object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
 /// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// entityToken is a pointer within buffer and does not need to be freed separately.
+/// </remarks>
 HRESULT <%- prefix %>EntityGetCachedEntityToken(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const <%- prefix %>EntityToken** entityToken
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityToken** entityToken,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept;
 
 }

--- a/source/code/include/playfab/PFTitlePlayer.h.ejs
+++ b/source/code/include/playfab/PFTitlePlayer.h.ejs
@@ -13,6 +13,11 @@ extern "C"
 {
 
 /// <summary>
+/// Entity type for all TitlePlayer Entities. This const value can be used to populate <%- prefix %>EntityKeys referrring to TitlePlayer Entities.
+/// </summary>
+static const char* <%- prefix %>TitlePlayerEntityType = "title_player_account";
+
+/// <summary>
 /// Handle to an authenticated TitlePlayer Entity. Returned from one of the <%- prefix %>AuthenticationClientLogin* APIs.
 /// When no longer needed, the Entity handle must be closed with <%- prefix %>TitlePlayerCloseHandle.
 /// </summary>
@@ -58,14 +63,29 @@ HRESULT <%- prefix %>TitlePlayerGetEntityHandle(
 ) noexcept;
 
 /// <summary>
-/// Get the PlayFabId for the TitlePlayer.
+/// Get the size in bytes needed to store the PlayFabId for a TitlePlayer.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="playFabId">Returned pointer to the playFabId. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the PlayFabId.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT <%- prefix %>TitlePlayerGetPlayFabIdSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* playFabIdSize
+) noexcept;
+
+/// <summary>
+/// Get the PlayFabId for a TitlePlayer.
+/// </summary>
+/// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
+/// <param name="playFabIdSize">The size in bytes of the playFabId buffer. The required size can be obtained from <%- prefix %>TitlePlayerGetPlayFabIdSize.</param>
+/// <param name="playFabId">The buffer the playFabId will be written to.</param>
+/// <param name="playFabIdUsed">The number of bytes used in the buffer including the null terminator.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>TitlePlayerGetPlayFabId(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const char** playFabId
+    _In_ size_t playFabIdSize,
+    _Out_writes_bytes_to_opt_(playFabIdSize, playFabIdUsed) char* playFabId,
+    _Out_opt_ size_t* playFabIdUsed
 ) noexcept;
 
 /// <summary>
@@ -83,86 +103,169 @@ HRESULT <%- prefix %>TitlePlayerGetCachedSessionTicketSize(
 /// Get the TitlePlayer's cached Client SessionTicket.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name='sessionTicketBufferSize'>The size of the provided SessionTicketBuffer, in bytes.</param>
+/// <param name='sessionTicketBufferSize'>The size of the provided SessionTicketBuffer, in bytes. The required size can be obtained from <%- prefix %>TitlePlayerGetCachedSessionTicketSize.</param>
 /// <param name='SessionTicketBuffer'>Buffer to write the Client SessionTicket into.</param>
 /// <param name='bufferUsed'>An optional pointer that contains the number of bytes written to the buffer.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>TitlePlayerGetCachedSessionTicket(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
     _In_ size_t sessionTicketBufferSize,
-    _Out_writes_bytes_to_opt_(sessionTicketSize, *bufferUsed) char* SessionTicketBuffer,
+    _Out_writes_bytes_to_opt_(sessionTicketBufferSize, *bufferUsed) char* SessionTicketBuffer,
     _Out_opt_ size_t* bufferUsed
 ) noexcept;
 
 /// <summary>
-/// Get the Entity Id for the TitlePlayer.
+/// Get the size in bytes needed to store the <%- prefix %>EntityKey for a TitlePlayer.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="entityId">Returned pointer to the entityId. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the EntityKey.</param>
 /// <returns>Result code for this API operation.</returns>
-HRESULT <%- prefix %>TitlePlayerGetEntityId(
+HRESULT <%- prefix %>TitlePlayerGetEntityKeySize(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const char** entityId
+    _Out_ size_t* bufferSize
+) noexcept;
+
+/// <summary>
+/// Get the <%- prefix %>EntityKey for a TitlePlayer.
+/// </summary>
+/// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>EntityKey. The required size can be obtained from <%- prefix %>TitlePlayerGetEntityKeySize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityKey and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>EntityKey object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
+/// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// entityKey is a pointer within buffer and does not need to be freed separately.
+/// </remarks>
+HRESULT <%- prefix %>TitlePlayerGetEntityKey(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityKey** entityKey,
+    _Out_opt_ size_t* bufferUsed
+) noexcept;
+
+/// <summary>
+/// Get the size in bytes needed to store the cached <%- prefix %>EntityToken for a TitlePlayer.
+/// </summary>
+/// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the cached <%- prefix %>EntityToken.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT <%- prefix %>TitlePlayerGetCachedEntityTokenSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
 ) noexcept;
 
 /// <summary>
 /// Get the cached Entity token.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="entityToken">Returned pointer to the entityToken. The pointer is valid until the TitlePlayer object is cleaned up, though
-/// the token may expire before then.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>EntityToken. The required size can be obtained from <%- prefix %>TitlePlayerGetCachedEntityTokenSize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityToken and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>EntityToken object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
 /// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// entityToken is a pointer within buffer and does not need to be freed separately.
+/// </remarks>
 HRESULT <%- prefix %>TitlePlayerGetCachedEntityToken(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const <%- prefix %>EntityToken** entityToken
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityToken** entityToken,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept;
 
 /// <summary>
-/// Get combined player info. Will be null if combined player info was not requested requested during login (see <see cref="<%- prefix %>GetPlayerCombinedInfoRequestParams"/>).
+/// Get the size in bytes needed to store the cached PlayerCombinedInfo for a TitlePlayer.
+/// Will be unavailable if combined player info was not requested requested during login (see <see cref="<%- prefix %>GetPlayerCombinedInfoRequestParams"/>) and
+/// bufferSize will be set to 0 in this case.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="playerCombinedInfo">Returned pointer to player combined info. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the cached PlayerCombinedInfo.</param>
+/// <returns>Result code for this API operation.</returns>
+HRESULT <%- prefix %>TitlePlayerGetPlayerCombinedInfoSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
+) noexcept;
+
+/// <summary>
+/// Get combined player info.
+/// </summary>
+/// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>GetPlayerCombinedInfoResultPayload.  The required size can be obtained from <%- prefix %>TitlePlayerGetPlayerCombinedInfoSize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityToken and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>EntityToken object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
 /// <returns>Result code for this API operation.</returns>
 /// <remarks>
-/// Note that the returned data is only guaranteed to be up to date as of the login request - it will not be automatically refreshed.
-/// To get updated combined player data, call <see cref="<%- prefix %>PlayerDataManagementGetPlayerCombinedInfoAsync"/>
+/// playerCombinedInfo is a pointer within buffer and does not need to be freed separately.
+/// The returned data is only guaranteed to be up to date as of the login request - it will not be automatically refreshed.
+/// To get updated combined player data call <see cref="<%- prefix %>PlayerDataManagementGetPlayerCombinedInfoAsync"/>
 /// </remarks>
 HRESULT <%- prefix %>TitlePlayerGetPlayerCombinedInfo(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>GetPlayerCombinedInfoResultPayload** playerCombinedInfo
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>GetPlayerCombinedInfoResultPayload** playerCombinedInfo,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept;
 
 /// <summary>
-/// Get last login time (prior to the login that resulted in this <%- prefix %>TitlePlayerHandle). lastLoginTime will be set to null if the player has no previous login.
+/// Get last login time (prior to the login that resulted in this <%- prefix %>TitlePlayerHandle). lastLoginTime will be set to 0 if the user has no previous logins.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="lastLoginTime">Returned pointer to the last login time. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="lastLoginTime">Populated with the TitlePlayers last login time, or 0 if the player has not logged in previously.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>TitlePlayerGetLastLoginTime(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const time_t** lastLoginTime
+    _Out_ time_t* lastLoginTime
 ) noexcept;
 
 /// <summary>
-/// Get UserSettings, if applicable. If unavailable, userSettings will be set to null.
+/// Get UserSettings. Will be unavailable if UserSettings were not requested requested during login (see <see cref="<%- prefix %>GetPlayerCombinedInfoRequestParams"/>).
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="lastLoginTime">Returned pointer to the UserSettings. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="userSettings">Populated UserSettings.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>TitlePlayerGetUserSettings(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>AuthenticationUserSettings** userSettings
+    _Out_ <%- prefix %>AuthenticationUserSettings* userSettings
 ) noexcept;
 
 /// <summary>
-/// Get experimentation treatments for a user at the time of login. If unavailable, treatmentAssignment will be set to null.
+/// Get the size in bytes needed to store the cached experimentation treatments for a TitlePlayer.
+/// Will be unavailable if treatmentAssignment was not requested requested during login (see <see cref="<%- prefix %>GetPlayerCombinedInfoRequestParams"/>) and
+/// bufferSize will be set to 0 in this case.
 /// </summary>
 /// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
-/// <param name="lastLoginTime">Returned pointer to TreatmentAssignment. Valid until the TitlePlayer object is cleaned up.</param>
+/// <param name="bufferSize">The buffer size in bytes required for the cached <%- prefix %>TreatmentAssignment.</param>
 /// <returns>Result code for this API operation.</returns>
+HRESULT <%- prefix %>TitlePlayerGetTreatmentAssignmentSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
+) noexcept;
+
+/// <summary>
+/// Get experimentation treatments for a user at the time of login.
+/// </summary>
+/// <param name="titlePlayerHandle"><%- prefix %>TitlePlayerHandle returned from a login call.</param>
+/// <param name="bufferSize">The size of the buffer for the <%- prefix %>TreatmentAssignment.  The required size can be obtained from <%- prefix %>TitlePlayerGetTreatmentAssignmentSize.</param>
+/// <param name="buffer">Byte buffer used for the <%- prefix %>EntityToken and its fields.</param>
+/// <param name="result">Pointer to the <%- prefix %>TreatmentAssignment object.</param>
+/// <param name="bufferUsed">The number of bytes in the provided buffer that were used.</param>
+/// <returns>Result code for this API operation.</returns>
+/// <remarks>
+/// treatmentAssignment is a pointer within buffer and does not need to be freed separately.
+/// The returned data is only guaranteed to be up to date as of the login request - it will not be automatically refreshed.
+/// To get updated experimentation treatments call <see cref="<%- prefix %>ExperimentationGetTreatmentAssignmentAsync"/>
+/// </remarks>
 HRESULT <%- prefix %>TitlePlayerGetTreatmentAssignment(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>TreatmentAssignment** treatmentAssignment
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>TreatmentAssignment** treatmentAssignment,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept;
 
 }

--- a/source/code/source/Api/PFEntity.cpp.ejs
+++ b/source/code/source/Api/PFEntity.cpp.ejs
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include <playfab/PFEntity.h>
+#include <playfab/<%- prefix %>Entity.h>
 #include "Entity.h"
 #include "ApiAsyncProviders.h"
 
@@ -75,38 +75,74 @@ HRESULT <%- prefix %>EntityGetEntityTokenGetResult(
     return XAsyncGetResult(async, nullptr, sizeof(<%- prefix %>EntityHandle), entityHandle, nullptr);
 }
 
-HRESULT <%- prefix %>EntityGetEntityId(
+HRESULT <%- prefix %>EntityGetEntityKeySize(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const char** entityId
+    _Out_ size_t* bufferSize
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(entityId);
+    RETURN_HR_INVALIDARG_IF_NULL(bufferSize);
 
-    *entityId = entityHandle->entity->EntityId().data();
+    *bufferSize = entityHandle->entity->EntityKey().RequiredBufferSize();
     return S_OK;
 }
 
-HRESULT <%- prefix %>EntityGetEntityType(
+HRESULT <%- prefix %>EntityGetEntityKey(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const char** entityType
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityKey** entityKey,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(entityType);
+    RETURN_HR_INVALIDARG_IF_NULL(buffer);
+    RETURN_HR_INVALIDARG_IF_NULL(entityKey);
 
-    *entityType = entityHandle->entity->EntityType().data();
+    ModelBuffer b{ buffer, bufferSize };
+    auto copyResult = entityHandle->entity->EntityKey().Copy(b);
+    RETURN_IF_FAILED(copyResult.hr);
+    *entityKey = copyResult.ExtractPayload();
+    if (bufferUsed)
+    {
+        *bufferUsed = bufferSize - b.RemainingSpace();
+    }
+    
+    return S_OK;
+}
+
+HRESULT <%- prefix %>EntityGetCachedEntityTokenSize(
+    _In_ <%- prefix %>EntityHandle entityHandle,
+    _Out_ size_t* bufferSize
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(bufferSize);
+
+    *bufferSize = entityHandle->entity->EntityToken()->RequiredBufferSize();
     return S_OK;
 }
 
 HRESULT <%- prefix %>EntityGetCachedEntityToken(
     _In_ <%- prefix %>EntityHandle entityHandle,
-    _Outptr_ const <%- prefix %>EntityToken** entityToken
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityToken** entityToken,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(buffer);
     RETURN_HR_INVALIDARG_IF_NULL(entityToken);
 
-    *entityToken = entityHandle->entity->EntityToken().get();
+    ModelBuffer b{ buffer, bufferSize };
+    auto copyResult = entityHandle->entity->EntityToken()->Copy(b);
+    RETURN_IF_FAILED(copyResult.hr);
+    *entityToken = copyResult.ExtractPayload();
+    if (bufferUsed)
+    {
+        *bufferUsed = bufferSize - b.RemainingSpace();
+    }
+
     return S_OK;
 }

--- a/source/code/source/Api/PFTitlePlayer.cpp.ejs
+++ b/source/code/source/Api/PFTitlePlayer.cpp.ejs
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include <playfab/PFTitlePlayer.h>
+#include <playfab/<%- prefix %>TitlePlayer.h>
 #include "TitlePlayer.h"
 
 using namespace PlayFab;
@@ -12,7 +12,7 @@ HRESULT <%- prefix %>TitlePlayerDuplicateHandle(
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
     RETURN_HR_INVALIDARG_IF_NULL(duplicatedHandle);
 
-    *duplicatedHandle = MakeUnique<PFTitlePlayer>(*titlePlayerHandle).release();
+    *duplicatedHandle = MakeUnique<<%- prefix %>TitlePlayer>(*titlePlayerHandle).release();
     return S_OK;
 }
 
@@ -20,7 +20,7 @@ void <%- prefix %>TitlePlayerCloseHandle(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle
 ) noexcept
 {
-    UniquePtr<PFTitlePlayer>{ titlePlayerHandle };
+    UniquePtr<<%- prefix %>TitlePlayer>{ titlePlayerHandle };
 }
 
 HRESULT <%- prefix %>TitlePlayerGetEntityHandle(
@@ -31,19 +31,44 @@ HRESULT <%- prefix %>TitlePlayerGetEntityHandle(
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
     RETURN_HR_INVALIDARG_IF_NULL(entityHandle);
 
-    *entityHandle = MakeUnique<PFEntity>(titlePlayerHandle->titlePlayer).release();
+    *entityHandle = MakeUnique<<%- prefix %>Entity>(titlePlayerHandle->titlePlayer).release();
+    return S_OK;
+}
+
+HRESULT <%- prefix %>TitlePlayerGetPlayFabIdSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* playFabIdSize
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(playFabIdSize);
+
+    *playFabIdSize = titlePlayerHandle->titlePlayer->PlayFabId().size() + 1;
     return S_OK;
 }
 
 HRESULT <%- prefix %>TitlePlayerGetPlayFabId(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const char** playFabId
+    _In_ size_t playFabIdSize,
+    _Out_writes_bytes_to_opt_(playFabIdSize, playFabIdUsed) char* playFabIdBuffer,
+    _Out_opt_ size_t* playFabIdUsed
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(playFabId);
+    RETURN_HR_INVALIDARG_IF_NULL(playFabIdBuffer);
 
-    *playFabId = titlePlayerHandle->titlePlayer->PlayFabId().data();
+    auto playFabId = titlePlayerHandle->titlePlayer->PlayFabId();
+    if (playFabId.size() + 1 > playFabIdSize)
+    {
+        return E_INVALIDARG;
+    }
+
+    std::strcpy(playFabIdBuffer, playFabId.data());
+    if (playFabIdUsed)
+    {
+        *playFabIdUsed = playFabId.size() + 1;
+    }
+
     return S_OK;
 }
 
@@ -97,74 +122,203 @@ HRESULT <%- prefix %>TitlePlayerGetCachedSessionTicket(
     return S_OK;
 }
 
-HRESULT <%- prefix %>TitlePlayerGetEntityId(
+HRESULT <%- prefix %>TitlePlayerGetEntityKeySize(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const char** entityId
+    _Out_ size_t* bufferSize
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(entityId);
 
-    *entityId = titlePlayerHandle->titlePlayer->EntityId().data();
-    return S_OK;
+    <%- prefix %>Entity entity{ titlePlayerHandle->titlePlayer };
+    return <%- prefix %>EntityGetEntityKeySize(&entity, bufferSize);
+}
+
+HRESULT <%- prefix %>TitlePlayerGetEntityKey(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityKey** entityKey,
+    _Out_opt_ size_t* bufferUsed
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
+
+    <%- prefix %>Entity entity{ titlePlayerHandle->titlePlayer };
+    return <%- prefix %>EntityGetEntityKey(&entity, bufferSize, buffer, entityKey, bufferUsed);
+}
+
+HRESULT <%- prefix %>TitlePlayerGetCachedEntityTokenSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
+
+    <%- prefix %>Entity entity{ titlePlayerHandle->titlePlayer };
+    return <%- prefix %>EntityGetCachedEntityTokenSize(&entity, bufferSize);
 }
 
 HRESULT <%- prefix %>TitlePlayerGetCachedEntityToken(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_ const <%- prefix %>EntityToken** entityToken
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>EntityToken** entityToken,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(entityToken);
 
-    *entityToken = titlePlayerHandle->titlePlayer->EntityToken().get();
+    <%- prefix %>Entity entity{ titlePlayerHandle->titlePlayer };
+    return <%- prefix %>EntityGetCachedEntityToken(&entity, bufferSize, buffer, entityToken, bufferUsed);
+}
+
+HRESULT <%- prefix %>TitlePlayerGetPlayerCombinedInfoSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(bufferSize);
+
+    auto& playerCombinedInfo = titlePlayerHandle->titlePlayer->PlayerCombinedInfo();
+    if (playerCombinedInfo)
+    {
+        *bufferSize = playerCombinedInfo->RequiredBufferSize();
+    }
+    else
+    {
+        *bufferSize = 0;
+    }
     return S_OK;
 }
 
 HRESULT <%- prefix %>TitlePlayerGetPlayerCombinedInfo(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>GetPlayerCombinedInfoResultPayload** playerCombinedInfo
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>GetPlayerCombinedInfoResultPayload** playerCombinedInfoPtr,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(playerCombinedInfo);
+    RETURN_HR_INVALIDARG_IF_NULL(buffer);
+    RETURN_HR_INVALIDARG_IF_NULL(playerCombinedInfoPtr);
 
-    *playerCombinedInfo = &titlePlayerHandle->titlePlayer->PlayerCombinedInfo()->Model(); 
+    ModelBuffer b{ buffer, bufferSize };
+    auto& playerCombinedInfo = titlePlayerHandle->titlePlayer->PlayerCombinedInfo();
+    if (playerCombinedInfo)
+    {
+        auto copyResult = playerCombinedInfo->Copy(b);
+        RETURN_IF_FAILED(copyResult.hr);
+        *playerCombinedInfoPtr = copyResult.ExtractPayload();
+    }
+    else
+    {
+        TRACE_INFORMATION("<%- prefix %>GetPlayerCombinedInfoResultPayload not cached for this TitlePlayer");
+        *playerCombinedInfoPtr = nullptr;
+    }
+
+    if (bufferUsed)
+    {
+        *bufferUsed = bufferSize - b.RemainingSpace();
+    }
+
     return S_OK;
 }
 
 HRESULT <%- prefix %>TitlePlayerGetLastLoginTime(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const time_t** lastLoginTime
+    _Out_ time_t* lastLoginTimePointer
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(lastLoginTime);
+    RETURN_HR_INVALIDARG_IF_NULL(lastLoginTimePointer);
 
-    *lastLoginTime = titlePlayerHandle->titlePlayer->LastLoginTime();
+    auto lastLoginTime = titlePlayerHandle->titlePlayer->LastLoginTime();
+    if (lastLoginTime)
+    {
+        *lastLoginTimePointer = *lastLoginTime;
+    }
+    else
+    {
+        // Set to default per header docs
+        *lastLoginTimePointer = time_t{ 0 };
+    }
+
     return S_OK;
 }
 
 HRESULT <%- prefix %>TitlePlayerGetUserSettings(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>AuthenticationUserSettings** userSettings
+    _Out_ <%- prefix %>AuthenticationUserSettings* userSettingsPtr
 ) noexcept
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(userSettings);
+    RETURN_HR_INVALIDARG_IF_NULL(userSettingsPtr);
 
-    *userSettings = &titlePlayerHandle->titlePlayer->UserSettings()->Model();
+    auto& userSettings = titlePlayerHandle->titlePlayer->UserSettings();
+    if (userSettings)
+    {
+        *userSettingsPtr = titlePlayerHandle->titlePlayer->UserSettings()->Model();
+    }
+    else
+    {
+        TRACE_INFORMATION("<%- prefix %>AuthenticationUserSettings not cached for this TitlePlayer");
+        *userSettingsPtr = {};
+    }
+    return S_OK;
+}
+
+HRESULT <%- prefix %>TitlePlayerGetTreatmentAssignmentSize(
+    _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
+    _Out_ size_t* bufferSize
+) noexcept
+{
+    RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
+    RETURN_HR_INVALIDARG_IF_NULL(bufferSize);
+
+    auto& treatmentAssignment = titlePlayerHandle->titlePlayer->TreatmentAssignment();
+    if (treatmentAssignment)
+    {
+        *bufferSize = treatmentAssignment->RequiredBufferSize();
+    }
+    else
+    {
+        *bufferSize = 0;
+    }
     return S_OK;
 }
 
 HRESULT <%- prefix %>TitlePlayerGetTreatmentAssignment(
     _In_ <%- prefix %>TitlePlayerHandle titlePlayerHandle,
-    _Outptr_result_maybenull_ const <%- prefix %>TreatmentAssignment** treatmentAssignment
+    _In_ size_t bufferSize,
+    _Out_writes_bytes_to_(bufferSize, *bufferUsed) void* buffer,
+    _Outptr_ const <%- prefix %>TreatmentAssignment** treatmentAssignmentPtr,
+    _Out_opt_ size_t* bufferUsed
 ) noexcept 
 {
     RETURN_HR_INVALIDARG_IF_NULL(titlePlayerHandle);
-    RETURN_HR_INVALIDARG_IF_NULL(treatmentAssignment);
+    RETURN_HR_INVALIDARG_IF_NULL(buffer);
+    RETURN_HR_INVALIDARG_IF_NULL(treatmentAssignmentPtr);
 
-    *treatmentAssignment = &titlePlayerHandle->titlePlayer->TreatmentAssignment()->Model();
+    ModelBuffer b{ buffer, bufferSize };
+    auto& treatmentAssignment = titlePlayerHandle->titlePlayer->TreatmentAssignment();
+    if (treatmentAssignment)
+    {
+        auto copyResult = treatmentAssignment->Copy(b);
+        RETURN_IF_FAILED(copyResult.hr);
+        *treatmentAssignmentPtr = copyResult.ExtractPayload();
+    }
+    else
+    {
+        TRACE_INFORMATION("<%- prefix %>TreatmentAssignment not cached for this TitlePlayer");
+        *treatmentAssignmentPtr = nullptr;
+    }
+
+    if (bufferUsed)
+    {
+        *bufferUsed = bufferSize - b.RemainingSpace();
+    }
+
     return S_OK;
 }

--- a/source/code/source/ApiAsyncProviders.h.ejs
+++ b/source/code/source/ApiAsyncProviders.h.ejs
@@ -82,10 +82,13 @@ protected:
     {
         assert(m_result.has_value());
         ModelBuffer b{ buffer, bufferSize };
-        auto result = m_result->Payload().Copy(b);
-        // TODO how to ensure offset of result object within buffer. Assume for now it will always be at byte 0
-        assert((void*)(result.Payload()) == buffer);
-        return result.hr;
+        auto copyResult = m_result->Payload().Copy(b);
+        if (SUCCEEDED(copyResult.hr))
+        {
+            // TODO how to ensure offset of result object within buffer. Assume for now it will always be at byte 0
+            assert((void*)(copyResult.Payload()) == buffer);
+        }
+        return copyResult.hr;
     }
 
     CallT m_call;

--- a/source/code/source/Entity.h
+++ b/source/code/source/Entity.h
@@ -22,6 +22,9 @@ public:
     EntityToken(EntityToken&& src);
     ~EntityToken() = default;
 
+    size_t RequiredBufferSize() const;
+    Result<PFEntityToken const*> Copy(ModelBuffer& buffer) const;
+
 private:
     String m_token;
     StdExtra::optional<time_t> m_expiration;
@@ -32,16 +35,15 @@ private:
 class Entity : public std::enable_shared_from_this<Entity>
 {
 public:
-    Entity(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, const Authentication::EntityTokenResponse& entityTokenResponse);
-    Entity(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, const Authentication::GetEntityTokenResponse& entityTokenResponse);
+    Entity(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, Authentication::EntityTokenResponse&& entityTokenResponse);
+    Entity(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, Authentication::GetEntityTokenResponse&& entityTokenResponse);
 
     Entity(const Entity&) = delete;
     Entity& operator=(const Entity&) = delete;
     ~Entity() = default;
 
 public:
-    String const& EntityId() const;
-    String const& EntityType() const;
+    EntityKey const& EntityKey() const;
     SharedPtr<PlayFab::EntityToken const> EntityToken() const;
 
     // Shared HttpClient
@@ -74,8 +76,7 @@ protected:
 
 private:
     // Entity attributes
-    String const m_id;
-    String const m_type;
+    PlayFab::EntityKey const m_key;
 };
 
 }

--- a/source/code/source/TitlePlayer.cpp
+++ b/source/code/source/TitlePlayer.cpp
@@ -7,36 +7,36 @@ namespace PlayFab
 
 using namespace Authentication;
 
-TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const LoginResult& result)
-    : Entity{ std::move(httpClient), std::move(qosAPI), *result.entityToken },
+TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, LoginResult&& result)
+    : Entity{ std::move(httpClient), std::move(qosAPI), std::move(*result.entityToken) },
     m_loginContext{ std::move(loginContext) },
-    m_playFabId{ result.playFabId },
+    m_playFabId{ std::move(result.playFabId) },
     m_sessionTicket{ MakeShared<String>(result.sessionTicket) },
-    m_playerCombinedInfo{ result.infoResultPayload.has_value() ? MakeUnique<GetPlayerCombinedInfoResultPayload>(*result.infoResultPayload) : nullptr },
-    m_lastLoginTime{ result.lastLoginTime },
-    m_userSettings{ result.settingsForUser },
-    m_treatmentAssignment{ result.treatmentAssignment.has_value() ? MakeUnique<PlayFab::TreatmentAssignment>(*result.treatmentAssignment) : nullptr }
+    m_playerCombinedInfo{ std::move(result.infoResultPayload) },
+    m_lastLoginTime{ std::move(result.lastLoginTime) },
+    m_userSettings{ std::move(result.settingsForUser) },
+    m_treatmentAssignment{ std::move(result.treatmentAssignment) }
 {
 }
 
-TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const ServerLoginResult& result)
-    : Entity{ std::move(httpClient), std::move(qosAPI), *result.entityToken },
+TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, ServerLoginResult&& result)
+    : Entity{ std::move(httpClient), std::move(qosAPI), std::move(*result.entityToken) },
     m_loginContext{ std::move(loginContext) },
-    m_playFabId{ result.playFabId },
+    m_playFabId{ std::move(result.playFabId) },
     m_sessionTicket{ MakeShared<String>(result.sessionTicket) },
-    m_playerCombinedInfo{ result.infoResultPayload.has_value() ? MakeUnique<GetPlayerCombinedInfoResultPayload>(*result.infoResultPayload) : nullptr },
-    m_lastLoginTime{ result.lastLoginTime },
-    m_userSettings{ result.settingsForUser },
-    m_treatmentAssignment{ result.treatmentAssignment.has_value() ? MakeUnique<PlayFab::TreatmentAssignment>(*result.treatmentAssignment) : nullptr }
+    m_playerCombinedInfo{ std::move(result.infoResultPayload) },
+    m_lastLoginTime{ std::move(result.lastLoginTime) },
+    m_userSettings{ std::move(result.settingsForUser) },
+    m_treatmentAssignment{ std::move(result.treatmentAssignment) }
 {
 }
 
-TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const RegisterPlayFabUserResult& result)
-    : Entity{ std::move(httpClient), std::move(qosAPI), *result.entityToken },
+TitlePlayer::TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, RegisterPlayFabUserResult&& result)
+    : Entity{ std::move(httpClient), std::move(qosAPI), std::move(*result.entityToken) },
     m_loginContext{ std::move(loginContext) },
-    m_playFabId{ result.playFabId },
+    m_playFabId{ std::move(result.playFabId) },
     m_sessionTicket{ MakeShared<String>(result.sessionTicket) },
-    m_userSettings{ result.settingsForUser }
+    m_userSettings{ std::move(result.settingsForUser) }
 {
 }
 
@@ -97,24 +97,24 @@ SharedPtr<String const> TitlePlayer::SessionTicket() const
     return m_sessionTicket;
 }
 
-GetPlayerCombinedInfoResultPayload const* TitlePlayer::PlayerCombinedInfo() const
+StdExtra::optional<GetPlayerCombinedInfoResultPayload> const& TitlePlayer::PlayerCombinedInfo() const
 {
-    return m_playerCombinedInfo.get();
+    return m_playerCombinedInfo;
 }
 
-time_t const* TitlePlayer::LastLoginTime() const
+StdExtra::optional<time_t const> const& TitlePlayer::LastLoginTime() const
 {
-    return m_lastLoginTime.has_value() ? m_lastLoginTime.operator->() : nullptr;
+    return m_lastLoginTime;
 }
 
-UserSettings const* TitlePlayer::UserSettings() const
+StdExtra::optional<UserSettings const> const& TitlePlayer::UserSettings() const
 {
-    return m_userSettings.has_value() ? m_userSettings.operator->() : nullptr;
+    return m_userSettings;
 }
 
-TreatmentAssignment const* TitlePlayer::TreatmentAssignment() const
+StdExtra::optional<TreatmentAssignment> const& TitlePlayer::TreatmentAssignment() const
 {
-    return m_treatmentAssignment.get();
+    return m_treatmentAssignment;
 }
 
 LoginContext::LoginContext(const char* requestPath)

--- a/source/code/source/TitlePlayer.h
+++ b/source/code/source/TitlePlayer.h
@@ -29,9 +29,9 @@ private:
 class TitlePlayer : public Entity
 {
 public:
-    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const Authentication::LoginResult& loginResult);
-    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const Authentication::ServerLoginResult& loginResult);
-    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, const Authentication::RegisterPlayFabUserResult& registerResult);
+    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, Authentication::LoginResult&& loginResult);
+    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, Authentication::ServerLoginResult&& loginResult);
+    TitlePlayer(SharedPtr<PlayFab::HttpClient const> httpClient, SharedPtr<QoS::QoSAPI const> qosAPI, SharedPtr<LoginContext const> loginContext, Authentication::RegisterPlayFabUserResult&& registerResult);
 
     TitlePlayer(const TitlePlayer&) = delete;
     TitlePlayer& operator=(const TitlePlayer&) = delete;
@@ -44,12 +44,11 @@ public:
     // Client SessionTicket for "Classic" PlayFab APIs
     SharedPtr<String const> SessionTicket() const;
 
-    // Getter methods to retreive TitlePlayer properties. All data only guaranteed to be accurate at the time of most recent login. Lifetime of returned data is tied
-    // to Entity object.
-    GetPlayerCombinedInfoResultPayload const* PlayerCombinedInfo() const;
-    time_t const* LastLoginTime() const;
-    Authentication::UserSettings const* UserSettings() const;
-    TreatmentAssignment const* TreatmentAssignment() const;
+    // Getter methods to retreive TitlePlayer properties. All data only guaranteed to be accurate at the time of most recent login. 
+    StdExtra::optional<GetPlayerCombinedInfoResultPayload> const& PlayerCombinedInfo() const;
+    StdExtra::optional<time_t const> const& LastLoginTime() const;
+    StdExtra::optional<Authentication::UserSettings const> const& UserSettings() const;
+    StdExtra::optional<TreatmentAssignment> const& TreatmentAssignment() const;
 
     // Refresh the cached Entity token by replaying login request
     AsyncOp<void> RefreshToken(const TaskQueue& queue) override;
@@ -60,10 +59,10 @@ private:
     String const m_playFabId;
     SharedPtr<String> m_sessionTicket;
 
-    UniquePtr<GetPlayerCombinedInfoResultPayload> m_playerCombinedInfo;
+    StdExtra::optional<GetPlayerCombinedInfoResultPayload> m_playerCombinedInfo;
     StdExtra::optional<time_t const> m_lastLoginTime;
     StdExtra::optional<Authentication::UserSettings const> m_userSettings;
-    UniquePtr<PlayFab::TreatmentAssignment> m_treatmentAssignment;
+    StdExtra::optional<PlayFab::TreatmentAssignment> m_treatmentAssignment;
 };
 
 }

--- a/templates/DataModels.cpp.ejs
+++ b/templates/DataModels.cpp.ejs
@@ -229,13 +229,29 @@ for (var propIdx = 0; propIdx < datatype.properties.length; propIdx++) {
     var templateParam = property.isclass ? ("<" + property.datatype.name + ">") : "";
 
     if (property.actualtype === "object") { %>
-    output.<%- propName %>.stringValue = buffer.CopyTo(input.<%- propName %>.stringValue);<%
+    {
+        auto propCopyResult = buffer.CopyTo(input.<%- propName %>.stringValue);
+        RETURN_IF_FAILED(propCopyResult.hr);
+        output.<%- propName %>.stringValue = propCopyResult.ExtractPayload();
+    }<%
     } else if (property.collection === "map") { %>
-    output.<%- propName %> = buffer.CopyToDictionary<%- templateParam %>(input.<%- propName %>, input.<%- propName %>Count);<%
+    {
+        auto propCopyResult = buffer.CopyToDictionary<%- templateParam %>(input.<%- propName %>, input.<%- propName %>Count);
+        RETURN_IF_FAILED(propCopyResult.hr);
+        output.<%- propName %> = propCopyResult.ExtractPayload();
+    }<%
     } else if (property.collection === "array") { %>
-    output.<%- propName %> = buffer.CopyToArray<%- templateParam %>(input.<%- propName %>, input.<%- propName %>Count);<%
+    {
+        auto propCopyResult = buffer.CopyToArray<%- templateParam %>(input.<%- propName %>, input.<%- propName %>Count);
+        RETURN_IF_FAILED(propCopyResult.hr);
+        output.<%- propName %> = propCopyResult.ExtractPayload();
+    }<%
     } else if (requiresDynamicStorage(property)) { %>
-    output.<%- propName %> = buffer.CopyTo<%- templateParam %>(input.<%- propName %>);<%
+    {
+        auto propCopyResult = buffer.CopyTo<%- templateParam %>(input.<%- propName %>); 
+        RETURN_IF_FAILED(propCopyResult.hr);
+        output.<%- propName %> = propCopyResult.ExtractPayload();
+    }<%
     }
 } // end for %>
     return S_OK;

--- a/templates/PFDataModels.h.ejs
+++ b/templates/PFDataModels.h.ejs
@@ -48,7 +48,11 @@ for (var typeIndex = 0; typeIndex < featureGroup.sortedClasses.length; typeIndex
     var datatype = featureGroup.sortedClasses[typeIndex];
     if (datatype.isInternalOnly) {
         continue;
-    } %>
+    } 
+    if (datatype.name === "EntityKey") { %>
+#ifndef PF_ENTITY_KEY_DEFINED
+#define PF_ENTITY_KEY_DEFINED<%
+    } // end if %>        
 /// <summary>
 <%- getFormattedDatatypeDescription(datatype) %>
 /// </summary>
@@ -58,8 +62,10 @@ for (var propertyIndex = 0; propertyIndex < datatype.properties.length; property
 %><%- getPropertyDefinition(datatype, property, false) %><% } %>
 } <%- datatype.prefix %><%- datatype.name %>;
 <% 
-// Explicitly add LoginWithXUserRequest type alongside LoginWithXboxRequest
-if (datatype.name === "ClientLoginWithXboxRequest") { %>
+    if (datatype.name === "EntityKey") { %>
+#endif // PF_ENTITY_KEY_DEFINED<%
+    } else if (datatype.name === "ClientLoginWithXboxRequest") { 
+        // Explicitly add LoginWithXUserRequest type alongside LoginWithXboxRequest %>
 #if HC_PLATFORM == HC_PLATFORM_GDK
 /// <summary>
 /// <%- prefix %>LoginWithXUserRequest data model. If this is the first time a user has signed in with
@@ -110,7 +116,7 @@ typedef struct <%- prefix %>LoginWithXUserRequest
 
 } <%- prefix %>LoginWithXUserRequest;
 #endif
-<% } // end if
+<%  } // end if
 } // end for
 
 if (featureGroup.name === "Shared") { %>

--- a/templates/PFDataModels.h.ejs
+++ b/templates/PFDataModels.h.ejs
@@ -52,7 +52,7 @@ for (var typeIndex = 0; typeIndex < featureGroup.sortedClasses.length; typeIndex
     if (datatype.name === "EntityKey") { %>
 #ifndef PF_ENTITY_KEY_DEFINED
 #define PF_ENTITY_KEY_DEFINED<%
-    } // end if %>        
+    } // end if %>
 /// <summary>
 <%- getFormattedDatatypeDescription(datatype) %>
 /// </summary>
@@ -62,9 +62,9 @@ for (var propertyIndex = 0; propertyIndex < datatype.properties.length; property
 %><%- getPropertyDefinition(datatype, property, false) %><% } %>
 } <%- datatype.prefix %><%- datatype.name %>;
 <% 
-    if (datatype.name === "EntityKey") { %>
-#endif // PF_ENTITY_KEY_DEFINED<%
-    } else if (datatype.name === "ClientLoginWithXboxRequest") { 
+    if (datatype.name === "EntityKey") { 
+%>#endif // PF_ENTITY_KEY_DEFINED
+<%  } else if (datatype.name === "ClientLoginWithXboxRequest") { 
         // Explicitly add LoginWithXUserRequest type alongside LoginWithXboxRequest %>
 #if HC_PLATFORM == HC_PLATFORM_GDK
 /// <summary>

--- a/templates/Test.cpp.ejs
+++ b/templates/Test.cpp.ejs
@@ -109,9 +109,6 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
 
                 hr = PFTitlePlayerGetEntityHandle(titlePlayerHandle, &entityHandle);
                 assert(SUCCEEDED(hr) && entityHandle);
-
-                hr = PFTitlePlayerGetPlayerCombinedInfo(titlePlayerHandle, &playerCombinedInfo);
-                assert(SUCCEEDED(hr));
             }
         }
 
@@ -131,9 +128,6 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
 
                 hr = PFTitlePlayerGetEntityHandle(titlePlayerHandle2, &entityHandle2);
                 assert(SUCCEEDED(hr) && entityHandle2);
-
-                hr = PFTitlePlayerGetPlayerCombinedInfo(titlePlayerHandle2, &playerCombinedInfo2);
-                assert(SUCCEEDED(hr));
             }
         }
 

--- a/templates/Test.h.ejs
+++ b/templates/Test.h.ejs
@@ -110,10 +110,8 @@ public:
     PFStateHandle stateHandle{ nullptr };
     PFTitlePlayerHandle titlePlayerHandle{ nullptr };
     PFEntityHandle entityHandle{ nullptr };
-    PFGetPlayerCombinedInfoResultPayload const* playerCombinedInfo{ nullptr };
     PFTitlePlayerHandle titlePlayerHandle2{ nullptr };
     PFEntityHandle entityHandle2{ nullptr };
-    PFGetPlayerCombinedInfoResultPayload const* playerCombinedInfo2{ nullptr };
     PFEntityHandle titleEntityHandle{ nullptr };
 
     void ClassSetUp() override;


### PR DESCRIPTION
* Return copies of cached Entity Models rather than pointers to internal memory
* Return PFEntityKey Model from PFEntityHandle (rather than EntityId and EntityType individually)
* I'd #ifndef guards to PFEntityKey definition so we don't conflict with definition from other PF SDKs
* Add proper error handling to ModelBuffer & OutputModel::Copy.