### PR TITLE
Customization of login requests

### DIFF
--- a/make.js
+++ b/make.js
@@ -289,13 +289,13 @@ function curateServiceApis(apis) {
     }
 }
 
-// Make several customizations to Login requests. Ideally long term hopefully the service contract can be modified so that these modifications aren't necessary,
+// Make several customizations to Login requests. Ideally long term the service contract can be modified so that these modifications aren't necessary,
 // but for know they lead to much cleaner client APIs.
 // 1) Remove titleId field since we already have that from PFInitialize and titles shouldn't need to provide it again
 // 2) Remove option for encrypted request (and update other optional accordingly)
 function customizeLoginRequest(requestDatatype) {
     assert(requestDatatype.properties);
- 
+
     for (var i = requestDatatype.properties.length - 1; i >= 0 ; i--) {
         let property = requestDatatype.properties[i];
         if (property.name === "TitleId") {
@@ -304,7 +304,7 @@ function customizeLoginRequest(requestDatatype) {
             requestDatatype.properties.splice(i, 1);
         }
 
-        // properties that are only marked optional because due to EncryptedRequest. Change to optional=false
+        // Properties that are only marked optional because of the optional to provide an encrypted request. Change "optional" to false.
         var nonOptionalLoginProperties = new Set(["CreateAccount", "AndroidDeviceId", "CustomId", "ServerAuthCode", "DeviceId", "AuthTicket", "KongregateId", "IdentityToken",
         "IdToken", "AuthCode", "SteamTicket", "AccessToken", "XboxToken", "Password", "ServerCustomId"]);
 

--- a/make.js
+++ b/make.js
@@ -1,3 +1,4 @@
+const { assert } = require("console");
 var path = require("path");
 const { fileURLToPath } = require("url");
 
@@ -281,7 +282,34 @@ function curateServiceApis(apis) {
             } else if (call.result && (call.resultDatatype.name.endsWith("LoginResult") || call.resultDatatype.name === "RegisterPlayFabUserResult")) {
                 call.entityReturned = "TitlePlayer";
                 call.resultDatatype.isInternalOnly = true;
+
+                customizeLoginRequest(call.requestDatatype);
             }
+        }
+    }
+}
+
+// Make several customizations to Login requests. Ideally long term hopefully the service contract can be modified so that these modifications aren't necessary,
+// but for know they lead to much cleaner client APIs.
+// 1) Remove titleId field since we already have that from PFInitialize and titles shouldn't need to provide it again
+// 2) Remove option for encrypted request (and update other optional accordingly)
+function customizeLoginRequest(requestDatatype) {
+    assert(requestDatatype.properties);
+ 
+    for (var i = requestDatatype.properties.length - 1; i >= 0 ; i--) {
+        let property = requestDatatype.properties[i];
+        if (property.name === "TitleId") {
+            requestDatatype.properties.splice(i, 1);
+        } else if (property.name === "EncryptedRequest") {
+            requestDatatype.properties.splice(i, 1);
+        }
+
+        // properties that are only marked optional because due to EncryptedRequest. Change to optional=false
+        var nonOptionalLoginProperties = new Set(["CreateAccount", "AndroidDeviceId", "CustomId", "ServerAuthCode", "DeviceId", "AuthTicket", "KongregateId", "IdentityToken",
+        "IdToken", "AuthCode", "SteamTicket", "AccessToken", "XboxToken", "Password", "ServerCustomId"]);
+
+        if (nonOptionalLoginProperties.has(property.name)) {
+            property.optional = false;
         }
     }
 }

--- a/project_files.json
+++ b/project_files.json
@@ -15,7 +15,7 @@
     "include\\playfab\\PFPal.h": "C Public Includes\\playfab",
     "include\\playfab\\PFQoS.h": "C Public Includes\\playfab",
     "include\\playfab\\PFTitlePlayer.h": "C Public Includes\\playfab",
-    "include\\playfab\\cpp\\ModelHelpers.h": "C Public Includes\\playfab\\cpp",
+    "include\\playfab\\cpp\\PFModelWrapperHelpers.h": "C Public Includes\\playfab\\cpp",
     "include\\playfab\\cpp\\StdOptional.h": "C Public Includes\\playfab\\cpp"
   },
   "sourceFiles": {

--- a/source/code/include/playfab/PFGlobal.h.ejs
+++ b/source/code/include/playfab/PFGlobal.h.ejs
@@ -85,12 +85,12 @@ typedef struct <%- prefix %>GlobalState* <%- prefix %>StateHandle;
 /// <summary>
 /// Create PlayFab global state.
 /// </summary>
-/// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
+/// <param name="playFabTitleId">PlayFab TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
 /// <param name="backgroundQueue">An XTaskQueue that should be used for background work. If no queue is a default (threadpool) queue will be used.</param>
 /// <param name="stateHandle">Pointer to <%- prefix %>StateHandle to write.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>Initialize(
-    _In_z_ const char* titleId,
+    _In_z_ const char* playFabTitleId,
     _In_opt_ XTaskQueueHandle backgroundQueue,
     _Outptr_ <%- prefix %>StateHandle* stateHandle
 ) noexcept;
@@ -99,13 +99,13 @@ HRESULT <%- prefix %>Initialize(
 /// <summary>
 /// Create PlayFab global state. Should be only used when implementing admin or server code.
 /// </summary>
-/// <param name="titleId">TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
+/// <param name="playFabTitleId">PlayFab TitleId for the title. Found in the Game Manager for your title on the PlayFab Website.</param>
 /// <param name="secretKey">Key to be used for Authentication for Server and Admin APIs.</param>
 /// <param name="backgroundQueue">An XTaskQueue that should be used for background work. If no queue is a default (threadpool) queue will be used.</param>
 /// <param name="stateHandle">Pointer to <%- prefix %>StateHandle to write.</param>
 /// <returns>Result code for this API operation.</returns>
 HRESULT <%- prefix %>AdminInitialize(
-    _In_z_ const char* titleId,
+    _In_z_ const char* playFabTitleId,
     _In_z_ const char* secretKey,
     _In_opt_ XTaskQueueHandle backgroundQueue,
     _Outptr_ <%- prefix %>StateHandle* stateHandle

--- a/source/code/source/GlobalState.cpp.ejs
+++ b/source/code/source/GlobalState.cpp.ejs
@@ -10,11 +10,17 @@ namespace PlayFab
 {
 
 GlobalState::GlobalState(String&& titleId, _In_opt_z_ const char* secretKey, _In_opt_ XTaskQueueHandle backgroundQueue) :
-    m_httpClient{ MakeShared<PlayFab::HttpClient>(std::move(titleId)) },
+    m_titleId{ std::move(titleId) },
+    m_httpClient{ MakeShared<PlayFab::HttpClient>(m_titleId) },
     m_secretKey{ secretKey ? MakeShared<String>(secretKey) : nullptr },
     m_qosAPI{ MakeShared<QoS::QoSAPI>() },
     m_backgroundQueue{ backgroundQueue }
 {
+}
+
+String const& GlobalState::TitleId() const
+{
+    return m_titleId;
 }
 
 SharedPtr<HttpClient const> GlobalState::HttpClient() const

--- a/source/code/source/GlobalState.h.ejs
+++ b/source/code/source/GlobalState.h.ejs
@@ -18,6 +18,7 @@ public:
     virtual ~GlobalState() = default;
 
 public:
+    String const& TitleId() const;
     SharedPtr<HttpClient const> HttpClient() const;
     SharedPtr<String const> SecretKey() const;
 
@@ -25,10 +26,10 @@ public:
     SharedPtr<QoS::QoSAPI const> QoSAPI() const;
 
 private:
+    String const m_titleId;
     SharedPtr<PlayFab::HttpClient> m_httpClient;
     SharedPtr<String> m_secretKey;
     SharedPtr<QoS::QoSAPI> m_qosAPI;
-
     TaskQueue m_backgroundQueue;
 };
 

--- a/source/code/source/HttpClient.cpp
+++ b/source/code/source/HttpClient.cpp
@@ -61,13 +61,13 @@ private:
     SharedPtr<AsyncOpContext<ServiceResponse>> m_asyncContext;
 };
 
-HttpClient::HttpClient(String&& titleId) :
+HttpClient::HttpClient(String titleId) :
     m_baseServiceHost{ productionEnvironmentURL },
     m_titleId{ std::move(titleId) }
 {
 }
 
-HttpClient::HttpClient(String&& baseServiceHost, String&& titleId) :
+HttpClient::HttpClient(String&& baseServiceHost, String titleId) :
     m_baseServiceHost{ std::move(baseServiceHost) },
     m_titleId{ std::move(titleId) }
 {

--- a/source/code/source/HttpClient.h
+++ b/source/code/source/HttpClient.h
@@ -20,8 +20,8 @@ constexpr char kSecretKeyHeaderName[]{ "X-SecretKey" };
 class HttpClient
 {
 public:
-    HttpClient(String&& titleId);
-    HttpClient(String&& baseServiceHost, String&& titleId);
+    HttpClient(String titleId);
+    HttpClient(String&& baseServiceHost, String titleId);
     HttpClient(const HttpClient&) = default;
     ~HttpClient() = default;
 

--- a/source/code/source/JsonUtils.cpp
+++ b/source/code/source/JsonUtils.cpp
@@ -76,6 +76,11 @@ JsonValue ToJson(const String& string)
 
 JsonValue ToJson(const PFJsonObject& jsonObject)
 {
+    // By design, map empty jsonObject to null JsonValue
+    if (!jsonObject.stringValue)
+    {
+        return JsonValue{ rapidjson::kNullType };
+    }
     JsonDocument document{ &allocator };
     document.Parse(jsonObject.stringValue);
     return JsonValue{ document, allocator };

--- a/source/test/TestApp/Tests/ApiTests.cpp
+++ b/source/test/TestApp/Tests/ApiTests.cpp
@@ -261,9 +261,7 @@ void ApiTests::ClassSetUp()
     {
         PFAuthenticationLoginWithCustomIDRequest request{};
         request.customId = "CustomId";
-        bool createAccount = true;
-        request.createAccount = &createAccount;
-        request.titleId = testTitleData.titleId.data();
+        request.createAccount = true;
 
         XAsyncBlock async{};
         hr = PFAuthenticationClientLoginWithCustomIDAsync(stateHandle, &request, &async);

--- a/source/test/TestApp/Tests/EntityTests.cpp
+++ b/source/test/TestApp/Tests/EntityTests.cpp
@@ -97,9 +97,12 @@ struct AuthResult : public XAsyncResult
             size_t bufferSize;
             RETURN_IF_FAILED(PFTitlePlayerGetPlayerCombinedInfoSize(titlePlayerHandle, &bufferSize));
 
-            std::vector<char> buffer(bufferSize);
-            PFGetPlayerCombinedInfoResultPayload const* playerCombinedInfo;
-            RETURN_IF_FAILED(PFTitlePlayerGetPlayerCombinedInfo(titlePlayerHandle, buffer.size(), buffer.data(), &playerCombinedInfo, nullptr));
+            if (bufferSize > 0)
+            {
+                std::vector<char> buffer(bufferSize);
+                PFGetPlayerCombinedInfoResultPayload const* playerCombinedInfo;
+                RETURN_IF_FAILED(PFTitlePlayerGetPlayerCombinedInfo(titlePlayerHandle, buffer.size(), buffer.data(), &playerCombinedInfo, nullptr));
+            }
         }
 
         {
@@ -116,10 +119,12 @@ struct AuthResult : public XAsyncResult
             size_t bufferSize;
             RETURN_IF_FAILED(PFTitlePlayerGetTreatmentAssignmentSize(titlePlayerHandle, &bufferSize));
 
-
-            std::vector<char> buffer(bufferSize);
-            PFTreatmentAssignment const* treatmentAssignment;
-            RETURN_IF_FAILED(PFTitlePlayerGetTreatmentAssignment(titlePlayerHandle, buffer.size(), buffer.data(), &treatmentAssignment, nullptr));
+            if (bufferSize > 0)
+            {
+                std::vector<char> buffer(bufferSize);
+                PFTreatmentAssignment const* treatmentAssignment;
+                RETURN_IF_FAILED(PFTitlePlayerGetTreatmentAssignment(titlePlayerHandle, buffer.size(), buffer.data(), &treatmentAssignment, nullptr));
+            }
         }
 
         return S_OK;
@@ -135,9 +140,8 @@ void EntityTests::TestClientLogin(TestContext& testContext)
 
     PFAuthenticationLoginWithCustomIDRequest request{};
     request.customId = "CustomId";
-    bool createAccount = true;
-    request.createAccount = &createAccount;
-    request.titleId = testTitleData.titleId.data();
+    request.createAccount = true;
+
     PFGetPlayerCombinedInfoRequestParams combinedInfoRequestParams{};
     combinedInfoRequestParams.getPlayerProfile = true;
     combinedInfoRequestParams.getTitleData = true;
@@ -167,9 +171,7 @@ void EntityTests::TestManualTokenRefresh(TestContext& testContext)
 
         PFAuthenticationLoginWithCustomIDRequest request{};
         request.customId = "CustomId";
-        bool createAccount = true;
-        request.createAccount = &createAccount;
-        request.titleId = testTitleData.titleId.data();
+        request.createAccount = true;
 
         HRESULT hr = PFAuthenticationClientLoginWithCustomIDAsync(stateHandle, &request, &async);
         if (FAILED(hr))
@@ -293,9 +295,7 @@ void EntityTests::TestLoginWithXUser(TestContext& testContext)
         auto async = std::make_unique<XAsyncHelper<AuthResult>>(testContext);
 
         PFAuthenticationLoginWithXUserRequest request{};
-        bool createAccount = true;
-        request.createAccount = &createAccount;
-        request.titleId = testTitleData.titleId.data();
+        request.createAccount = true;
         request.userHandle = xUser.handle;
 
         hr = PFAuthenticationLoginWithXUserAsync(stateHandle, &request, &async->asyncBlock);

--- a/templates/Calls.cpp.ejs
+++ b/templates/Calls.cpp.ejs
@@ -3,7 +3,8 @@
 #include "GlobalState.h"
 #include "TitlePlayer.h"<%
 if (featureGroup.name === "Authentication") { %>
-#include "PlatformUser.h"<%
+#include "PlatformUser.h"
+#include "JsonUtils.h"<%
 } %>
 
 namespace PlayFab
@@ -85,6 +86,10 @@ for (var i = 0; i < featureGroup.calls.length; i++) {
     }
     var requestParam = call.requestDatatype ? "const " + call.requestDatatype.name + "& request,\n    " : ""; 
     var requestBody = call.requestDatatype ? "JsonValue requestBody{ request.ToJson() };" : "JsonValue requestBody{ rapidjson::kNullType };";
+    if (call.entityReturned === "TitlePlayer") {
+        // add TitleId for login calls
+        requestBody += "\n    JsonUtils::ObjectAddMember(requestBody, \"TitleId\", state->TitleId());";
+    }
     var entityParam = call.entityRequired ? "entity,\n        " : "";
 
 %>
@@ -149,27 +154,27 @@ if (call.url === "/Client/LoginWithXbox") { %>
 class XUserLoginContext : public LoginContext
 {
 public:
-    XUserLoginContext(XUser&& platformUser, const PFAuthenticationLoginWithXUserRequest& request);
+    XUserLoginContext(XUser&& platformUser, String titleId, const PFAuthenticationLoginWithXUserRequest& request);
 
     AsyncOp<JsonValue> GetRequestBody(const TaskQueue& queue) const override;
 
 private:
     XUser m_platformUser;
+    String m_titleId;
     ClientLoginWithXboxRequest m_request;
 };
 
-XUserLoginContext::XUserLoginContext(XUser&& platformUser, const PFAuthenticationLoginWithXUserRequest& request)
+XUserLoginContext::XUserLoginContext(XUser&& platformUser, String titleId, const PFAuthenticationLoginWithXUserRequest& request)
     : LoginContext{ "/Client/LoginWithXbox" },
     m_platformUser{ std::move(platformUser) },
+    m_titleId{ std::move(titleId) },
     m_request{ PFAuthenticationClientLoginWithXboxRequest
     {
         request.createAccount,
         request.customTags,
         request.customTagsCount,
-        nullptr, // encryptedRequest
         request.infoRequestParameters,
         request.playerSecret,
-        request.titleId,
         nullptr // XboxToken, will be populated later
     }
     }
@@ -186,11 +191,13 @@ AsyncOp<JsonValue> XUserLoginContext::GetRequestBody(const TaskQueue& queue) con
         0,
         nullptr,
         queue
-    ).Then([request{ this->m_request }](Result<TokenAndSignature> getTokenResult) mutable -> Result<JsonValue>
+    ).Then([request{ this->m_request }, titleId{ this->m_titleId }](Result<TokenAndSignature> getTokenResult) mutable->Result<JsonValue>
     {
         RETURN_IF_FAILED(getTokenResult.hr);
-        request.xboxToken = getTokenResult.Payload().token.data();
-        return request.ToJson();
+        request.SetXboxToken(getTokenResult.Payload().token);
+        auto requestJson = request.ToJson();
+        JsonUtils::ObjectAddMember(requestJson, "TitleId", titleId);
+        return requestJson;
     });
 }
 
@@ -203,7 +210,7 @@ AsyncOp<SharedPtr<TitlePlayer>> AuthenticationAPI::LoginWithXUser(
     auto wrapUserHandleResult = XUser::WrapHandle(request.userHandle);
     RETURN_IF_FAILED(wrapUserHandleResult.hr);
 
-    auto loginContext = MakeShared<XUserLoginContext>(wrapUserHandleResult.ExtractPayload(), request);
+    auto loginContext = MakeShared<XUserLoginContext>(wrapUserHandleResult.ExtractPayload(), state->TitleId(), request);
 
     return loginContext->GetRequestBody(queue.DeriveWorkerQueue()).Then([ httpClient{ state->HttpClient() }, queue = TaskQueue{ queue }, loginContext](Result<JsonValue> requestBodyResult) -> AsyncOp<ServiceResponse>
     {

--- a/templates/PFDataModels.h.ejs
+++ b/templates/PFDataModels.h.ejs
@@ -78,9 +78,9 @@ for (var propertyIndex = 0; propertyIndex < datatype.properties.length; property
 typedef struct <%- prefix %>LoginWithXUserRequest
 {
     /// <summary>
-    /// (Optional) Automatically create a PlayFab account if one is not currently linked to this ID.
+    /// Automatically create a PlayFab account if one is not currently linked to this ID.
     /// </summary>
-    _Maybenull_ bool const* createAccount;
+    bool createAccount;
 
     /// <summary>
     /// (Optional) The optional custom tags associated with the request (e.g. build number, external
@@ -102,12 +102,6 @@ typedef struct <%- prefix %>LoginWithXUserRequest
     /// (Optional) Player secret that is used to verify API request signatures (Enterprise Only).
     /// </summary>
     _Maybenull_ _Null_terminated_ const char* playerSecret;
-
-    /// <summary>
-    /// Unique identifier for the title, found in the Settings > Game Properties section of the PlayFab
-    /// developer site when a title has been selected.
-    /// </summary>
-    _Null_terminated_ const char* titleId;
 
     /// <summary>
     /// XUserHandle returned from XUserAddAsync or XUserAddByIdWithUiAsync.

--- a/templates/Test.cpp.ejs
+++ b/templates/Test.cpp.ejs
@@ -77,9 +77,7 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
     {
         PFAuthenticationLoginWithCustomIDRequest request{};
         request.customId = "CustomId";
-        bool createAccount = true;
-        request.createAccount = &createAccount;
-        request.titleId = testTitleData.titleId.data();
+        request.createAccount = true;
 
         PFGetPlayerCombinedInfoRequestParams combinedInfoRequestParams{};
         combinedInfoRequestParams.getCharacterInventories = true;
@@ -99,7 +97,7 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
         assert(SUCCEEDED(hr));
         if (SUCCEEDED(hr))
         {
-            // Synchronously what for login to complete
+            // Synchronously wait for login to complete
             hr = XAsyncGetStatus(&async, true);
             assert(SUCCEEDED(hr));
             if (SUCCEEDED(hr))
@@ -137,7 +135,7 @@ void AutoGen<%- featureGroup.name %>Tests::ClassSetUp()
         assert(SUCCEEDED(hr));
         if (SUCCEEDED(hr))
         {
-            // Synchronously what for login to complete
+            // Synchronously wait for login to complete
             hr = XAsyncGetStatus(&async, true);
             assert(SUCCEEDED(hr));
             


### PR DESCRIPTION
* Customize Login request models:
  * Remove titleId since we will already know that from PFInitialize - it will be automatically added to the Http request by the SDK before it is sent.
  * Remove encrypted request since we don't want to support that.  Fields that were only marked as "optional" because of the option to provide an encrypted request are now required.
* Fix a small bug in JsonUtils where optional PFJsonObject fields were always assumed to be populated